### PR TITLE
feat(ci): adding a github action to publish pip package to pypi

### DIFF
--- a/.github/workflows/docker-ingestion-acryl.yml
+++ b/.github/workflows/docker-ingestion-acryl.yml
@@ -1,0 +1,73 @@
+name: datahub-ingestion docker acryl
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-ingestion-acryl.yml'
+    paths_ignore:
+      - '**.md'
+      - '**.env'
+  release:
+    types: [published, edited]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      publish: ${{ steps.publish.outputs.publish }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
+        run: |
+          echo "GITHUB_REF: $GITHUB_REF"
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,head\,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          echo "tag=$TAG"
+          echo "::set-output name=tag::$TAG"
+      - name: Check whether publishing enabled
+        id: publish
+        env:
+          ENABLE_PUBLISH: ${{ secrets.ORG_DOCKER_PASSWORD }}
+        run: |
+          echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+          echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  push_to_registries:
+    name: Build and Push Docker Image to Docker Hub
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            acryldata/datahub-ingestion
+          # add git short SHA as Docker tag
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
+      - name: Login to DockerHub
+        if: ${{ needs.setup.outputs.publish == 'true' }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.ORG_DOCKER_PASSWORD }}
+      - name: Build and Push image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/datahub-ingestion/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/publish-pypi-release.yml
+++ b/.github/workflows/publish-pypi-release.yml
@@ -1,0 +1,44 @@
+name: pypi-release metadata-ingestion
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
+        run: |
+          echo "GITHUB_REF: $GITHUB_REF"
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/tags/v,,g' -e 's,refs/tags/acryl,,g')
+          echo "tag=$TAG"
+          echo "::set-output name=tag::$TAG"
+  push_to_pypi:
+    name: Build and push python package to PyPI
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine build    
+    - name: Install dependencies
+      run: ./metadata-ingestion/scripts/install_deps.sh
+    - name: Build and publish   
+      env:
+        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+      run: |
+        cd metadata-ingestion
+        RELEASE_VERSION=${{ needs.setup.outputs.tag }} ./scripts/release.sh

--- a/.github/workflows/publish-pypi-release.yml
+++ b/.github/workflows/publish-pypi-release.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   setup:
+    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
@@ -16,7 +17,7 @@ jobs:
         run: |
           echo "GITHUB_REF: $GITHUB_REF"
           SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
-          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/tags/v,,g' -e 's,refs/tags/acryl,,g')
+          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/tags/v,,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
   push_to_pypi:


### PR DESCRIPTION
This will allow us to release pip package on a public release schedule while being de-coupled from mainline server release. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
