### PR TITLE
fix(airflow docker): do not run on publish only on pypi release

### DIFF
--- a/.github/workflows/docker-airflow-acryl.yml
+++ b/.github/workflows/docker-airflow-acryl.yml
@@ -4,8 +4,6 @@ on:
     workflows: ["pypi-release metadata-ingestion"]
     types:
       - completed
-  release:
-    types: [published, edited]
 
 jobs:
   setup:


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
