### PR TITLE
feat: allow configuring a custom query for Snowflake Usage

### DIFF
--- a/metadata-ingestion/source_docs/snowflake.md
+++ b/metadata-ingestion/source_docs/snowflake.md
@@ -271,7 +271,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `user_email_pattern.allow`      |          | *                                                                   | List of regex patterns for user emails to include in usage.                      |
 | `user_email_pattern.deny`       |          |                                                                     | List of regex patterns for user emails to exclude from usage.                    |
 | `user_email_pattern.ignoreCase` |          | `True`                                                              | Whether to ignore case sensitivity during pattern matching.                      |
-
+| `usage_custom_sql_template` |          |                                                                         | A custom SQL statement template which replaces the default `SNOWFLAKE_USAGE_SQL_TEMPLATE` (see source code for details).                      |
 :::caution
 
 User's without email address will be ignored from usage if you don't set `email_domain` property.

--- a/metadata-ingestion/source_docs/snowflake.md
+++ b/metadata-ingestion/source_docs/snowflake.md
@@ -272,6 +272,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `user_email_pattern.deny`       |          |                                                                     | List of regex patterns for user emails to exclude from usage.                    |
 | `user_email_pattern.ignoreCase` |          | `True`                                                              | Whether to ignore case sensitivity during pattern matching.                      |
 | `usage_custom_sql_template` |          |                                                                         | A custom SQL statement template which replaces the default `SNOWFLAKE_USAGE_SQL_TEMPLATE` (see source code for details).                      |
+
 :::caution
 
 User's without email address will be ignored from usage if you don't set `email_domain` property.

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -272,8 +272,9 @@ class SnowflakeUsageSource(StatefulIngestionSourceBase):
 
     def _make_usage_query(self) -> str:
         start_time = int(self.config.start_time.timestamp() * 1000)
-        end_time = int(self.config.end_time.timestamp() * 1000)
-        return SNOWFLAKE_USAGE_SQL_TEMPLATE.format(
+        end_time = int(self.config.end_time.timestamp() * 1000)        
+        usage_sql_template = self.config.usage_custom_sql_template.strip() or SNOWFLAKE_USAGE_SQL_TEMPLATE       
+        return usage_sql_template.format(
             start_time_millis=start_time,
             end_time_millis=end_time,
         )

--- a/metadata-ingestion/src/datahub/ingestion/source_config/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/usage/snowflake_usage.py
@@ -37,7 +37,7 @@ class SnowflakeUsageConfig(
     view_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     apply_view_usage_to_tables: bool = False
     stateful_ingestion: Optional[SnowflakeStatefulIngestionConfig] = None
-    usage_custom_query: Optional[str]
+    usage_custom_sql_template: Optional[str]
 
     def get_sql_alchemy_url(self):
         return super().get_sql_alchemy_url(

--- a/metadata-ingestion/src/datahub/ingestion/source_config/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/usage/snowflake_usage.py
@@ -37,6 +37,7 @@ class SnowflakeUsageConfig(
     view_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     apply_view_usage_to_tables: bool = False
     stateful_ingestion: Optional[SnowflakeStatefulIngestionConfig] = None
+    usage_custom_query: Optional[str]
 
     def get_sql_alchemy_url(self):
         return super().get_sql_alchemy_url(


### PR DESCRIPTION

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

## Foreword

This is my first PR here and I noticed too late that commit messages should be formatted in a specific way.  
Furthermore, my commits are so fine-grained that a single one of them does not fit any `type` classification.

So, I hope you bear with me or otherwise tell me how to restructure the PR.


## Motivation

The hard-coded `SNOWFLAKE_USAGE_SQL_TEMPLATE` has some drawbacks:

* `user_email_pattern.deny` apparently leads to empty Top-N query lists if the denied users make up most of the top queries. This is very common, e.g. for technical dbt users which run hundreds of tests.
* Technical proxy users which sometimes are used for user impersonation cannot be resolved to the email addresses of the impersonated users.

Therefore we were looking for a way to override the built-in query template.


## Implementation

* Create a new config option for the `snowflake-usage` source which allows for overriding the SQL template.
This option is called `usage_custom_sql_template`.
* Use the query defined in this config option, if present. Otherwise fallback to the built-in `SNOWFLAKE_USAGE_SQL_TEMPLATE`
* Add minimal documentation only, as it would be tricky to describe the whole `SNOWFLAKE_USAGE_SQL_TEMPLATE` query's columns and variables.


## Final words

I am not sure how to test this feature and if tests would be needed here.
I would be grateful if I could get some guidance so we could get this PR accepted.
