### PR TITLE
fix(build): run airflow docker build only run on pypi-release

### DIFF
--- a/.github/workflows/docker-airflow-acryl.yml
+++ b/.github/workflows/docker-airflow-acryl.yml
@@ -1,13 +1,13 @@
 name: datahub-airflow docker acryl
 on:
   workflow_run:
-    workflows: ["pypi-release metadata-ingestion"]
+    workflows: ["pypi-release"]
     types:
       - completed
 
 jobs:
   setup:
-    # if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
This was last released 6 months ago https://hub.docker.com/r/acryldata/airflow-datahub/tags. If we only run on pypi-release complete then the tag calc should work. Not sure why Dexter had removed the if condition

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)