### PR TITLE
feat(gha): make release workflow manually runable

### DIFF
--- a/.github/workflows/publish-airflow-plugin-pypi-release.yml
+++ b/.github/workflows/publish-airflow-plugin-pypi-release.yml
@@ -1,5 +1,6 @@
 name: pypi-release acryl-datahub-airflow-plugin
 on:
+  workflow_dispatch: 
   release:
     types: [published]
 

--- a/.github/workflows/publish-datahub-jars.yml
+++ b/.github/workflows/publish-datahub-jars.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - "docs/**"
       - "**.md"
+  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
Github doesn't want to run release workflow, when a release is create. This PR will enable users to run workflows.
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)