### PR TITLE
fix: add java version to pypi release script

### DIFF
--- a/.github/workflows/publish-airflow-plugin-pypi-release.yml
+++ b/.github/workflows/publish-airflow-plugin-pypi-release.yml
@@ -26,10 +26,15 @@ jobs:
     needs: setup
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        python-version: '3.10'
+        distribution: "zulu"
+        java-version: 17
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+        cache: "pip"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/publish-pypi-release.yml
+++ b/.github/workflows/publish-pypi-release.yml
@@ -26,10 +26,15 @@ jobs:
     needs: setup
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        python-version: '3.10'
+        distribution: "zulu"
+        java-version: 17
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+        cache: "pip"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Example failure: https://github.com/acryldata/datahub/actions/runs/7506727661/job/20438777265

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
