### PR TITLE
OSS Master Merge

### DIFF
--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -38,9 +38,6 @@ jobs:
       matrix:
         include:
           # Note: this should be kept in sync with tox.ini.
-          - python-version: "3.9"
-            extra_pip_requirements: "apache-airflow~=2.7.3"
-            extra_pip_constraints: "-c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.9.txt"
           - python-version: "3.10"
             extra_pip_requirements: "apache-airflow~=2.7.3"
             extra_pip_constraints: "-c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.10.txt"

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
@@ -103,11 +103,15 @@ public class OwnerUtils {
           input.getType() != null
               ? OwnershipType.valueOf(input.getType().toString())
               : OwnershipType.NONE;
+      final Urn ownershipTypeUrn =
+          input.getOwnershipTypeUrn() != null
+              ? UrnUtils.getUrn(input.getOwnershipTypeUrn())
+              : UrnUtils.getUrn(mapOwnershipTypeToEntity(ownershipType.name()));
       OwnerServiceUtils.addOwnerToAspect(
           ownershipAspect,
           UrnUtils.getUrn(input.getOwnerUrn()),
           com.linkedin.common.OwnershipType.valueOf(ownershipType.toString()),
-          UrnUtils.getUrn(input.getOwnershipTypeUrn()),
+          ownershipTypeUrn,
           OwnershipSourceType.MANUAL);
     }
     return buildMetadataChangeProposalWithUrn(

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -11659,6 +11659,12 @@ input CreateDomainInput {
   Optional parent domain urn for the domain
   """
   parentDomain: String
+
+  """
+  Optional - Add owners to the domain.
+  If not provided, we'll automatically assign the current actor as the owner.
+  """
+  owners: [OwnerInput!]
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/CreateDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/CreateDomainResolverTest.java
@@ -4,13 +4,17 @@ import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.DOMAIN_PROPERTIES_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
+import com.google.common.collect.ImmutableList;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.CreateDomainInput;
+import com.linkedin.datahub.graphql.generated.OwnerEntityType;
+import com.linkedin.datahub.graphql.generated.OwnerInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.DomainUtils;
 import com.linkedin.domain.DomainProperties;
 import com.linkedin.entity.Aspect;
@@ -39,15 +43,34 @@ public class CreateDomainResolverTest {
 
   private static final Urn TEST_DOMAIN_URN = Urn.createFromTuple("domain", "test-id");
   private static final Urn TEST_PARENT_DOMAIN_URN = Urn.createFromTuple("domain", "test-parent-id");
+  private static final Urn TEST_OWNER_URN = UrnUtils.getUrn("urn:li:corpuser:test-owner");
+  private static final Urn TEST_ACTOR_URN = UrnUtils.getUrn("urn:li:corpuser:test");
 
   private static final CreateDomainInput TEST_INPUT =
       new CreateDomainInput(
-          "test-id", "test-name", "test-description", TEST_PARENT_DOMAIN_URN.toString());
+          "test-id", "test-name", "test-description", TEST_PARENT_DOMAIN_URN.toString(), null);
 
   private static final CreateDomainInput TEST_INPUT_NO_PARENT_DOMAIN =
-      new CreateDomainInput("test-id", "test-name", "test-description", null);
+      new CreateDomainInput("test-id", "test-name", "test-description", null, null);
 
-  private static final Urn TEST_ACTOR_URN = UrnUtils.getUrn("urn:li:corpuser:test");
+  private static final OwnerInput TEST_OWNER_INPUT =
+      new OwnerInput(
+          TEST_OWNER_URN.toString(),
+          OwnerEntityType.CORP_USER,
+          com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER,
+          null);
+
+  private static final CreateDomainInput TEST_INPUT_WITH_OWNERS =
+      new CreateDomainInput(
+          "test-id",
+          "test-name",
+          "test-description",
+          TEST_PARENT_DOMAIN_URN.toString(),
+          ImmutableList.of(TEST_OWNER_INPUT));
+
+  private static final CreateDomainInput TEST_INPUT_NO_PARENT_WITH_OWNERS =
+      new CreateDomainInput(
+          "test-id", "test-name", "test-description", null, ImmutableList.of(TEST_OWNER_INPUT));
 
   @Test
   public void testGetSuccess() throws Exception {
@@ -59,6 +82,10 @@ public class CreateDomainResolverTest {
     Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
 
     Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_PARENT_DOMAIN_URN))).thenReturn(true);
+
+    // Mock the domain URN that will be returned from ingestProposal
+    Mockito.when(mockClient.ingestProposal(any(), any(), Mockito.eq(false)))
+        .thenReturn(TEST_DOMAIN_URN.toString());
 
     // Execute resolver
     QueryContext mockContext = getMockAllowContext();
@@ -108,6 +135,10 @@ public class CreateDomainResolverTest {
 
     Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
 
+    // Mock the domain URN that will be returned from ingestProposal
+    Mockito.when(mockClient.ingestProposal(any(), any(), Mockito.eq(false)))
+        .thenReturn(TEST_DOMAIN_URN.toString());
+
     QueryContext mockContext = getMockAllowContext();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT_NO_PARENT_DOMAIN);
@@ -141,6 +172,205 @@ public class CreateDomainResolverTest {
     Mockito.verify(mockClient, Mockito.times(1))
         .ingestProposal(
             any(), Mockito.argThat(new CreateDomainProposalMatcher(proposal)), Mockito.eq(false));
+  }
+
+  @Test
+  public void testGetSuccessWithOwners() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    EntityService<?> mockService = getMockEntityService();
+    CreateDomainResolver resolver = new CreateDomainResolver(mockClient, mockService);
+
+    Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
+    Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_PARENT_DOMAIN_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(any(), Mockito.eq(TEST_OWNER_URN), eq(true))).thenReturn(true);
+
+    // Mock the domain URN that will be returned from ingestProposal
+    Mockito.when(mockClient.ingestProposal(any(), any(), Mockito.eq(false)))
+        .thenReturn(TEST_DOMAIN_URN.toString());
+
+    // Mock ownership type URNs that OwnerUtils.addOwnersToResources checks for
+    Mockito.when(
+            mockService.exists(
+                any(),
+                Mockito.eq(UrnUtils.getUrn("urn:li:ownershipType:__system__technical_owner")),
+                Mockito.eq(true)))
+        .thenReturn(true);
+    Mockito.when(
+            mockService.exists(
+                any(),
+                Mockito.eq(UrnUtils.getUrn("urn:li:ownershipType:__system__none")),
+                Mockito.eq(true)))
+        .thenReturn(true);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT_WITH_OWNERS);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Mockito.when(
+            mockClient.filter(
+                any(),
+                Mockito.eq(Constants.DOMAIN_ENTITY_NAME),
+                Mockito.eq(
+                    DomainUtils.buildNameAndParentDomainFilter(
+                        TEST_INPUT_WITH_OWNERS.getName(), TEST_PARENT_DOMAIN_URN)),
+                Mockito.eq(null),
+                Mockito.any(Integer.class),
+                Mockito.any(Integer.class)))
+        .thenReturn(new SearchResult().setEntities(new SearchEntityArray()));
+
+    resolver.get(mockEnv).get();
+
+    // Verify domain creation
+    final DomainKey key = new DomainKey();
+    key.setId("test-id");
+    final MetadataChangeProposal domainProposal = new MetadataChangeProposal();
+    domainProposal.setEntityKeyAspect(GenericRecordUtils.serializeAspect(key));
+    domainProposal.setEntityType(Constants.DOMAIN_ENTITY_NAME);
+    DomainProperties props = new DomainProperties();
+    props.setDescription("test-description");
+    props.setName("test-name");
+    props.setCreated(new AuditStamp().setActor(TEST_ACTOR_URN).setTime(0L));
+    props.setParentDomain(TEST_PARENT_DOMAIN_URN);
+    domainProposal.setAspectName(Constants.DOMAIN_PROPERTIES_ASPECT_NAME);
+    domainProposal.setAspect(GenericRecordUtils.serializeAspect(props));
+    domainProposal.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockClient, Mockito.times(1))
+        .ingestProposal(
+            any(),
+            Mockito.argThat(new CreateDomainProposalMatcher(domainProposal)),
+            Mockito.eq(false));
+
+    // Verify owners are added
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(any(), any(), Mockito.eq(false));
+  }
+
+  @Test
+  public void testGetSuccessNoParentDomainWithOwners() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    EntityService<?> mockService = getMockEntityService();
+    CreateDomainResolver resolver = new CreateDomainResolver(mockClient, mockService);
+
+    Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(any(), Mockito.eq(TEST_OWNER_URN), eq(true))).thenReturn(true);
+
+    // Mock the domain URN that will be returned from ingestProposal
+    Mockito.when(mockClient.ingestProposal(any(), any(), Mockito.eq(false)))
+        .thenReturn(TEST_DOMAIN_URN.toString());
+
+    // Mock ownership type URNs that OwnerUtils.addOwnersToResources checks for
+    Mockito.when(
+            mockService.exists(
+                any(),
+                Mockito.eq(UrnUtils.getUrn("urn:li:ownershipType:__system__technical_owner")),
+                Mockito.eq(true)))
+        .thenReturn(true);
+    Mockito.when(
+            mockService.exists(
+                any(),
+                Mockito.eq(UrnUtils.getUrn("urn:li:ownershipType:__system__none")),
+                Mockito.eq(true)))
+        .thenReturn(true);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input")))
+        .thenReturn(TEST_INPUT_NO_PARENT_WITH_OWNERS);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Mockito.when(
+            mockClient.filter(
+                any(),
+                Mockito.eq(Constants.DOMAIN_ENTITY_NAME),
+                Mockito.eq(DomainUtils.buildNameAndParentDomainFilter(TEST_INPUT.getName(), null)),
+                Mockito.eq(null),
+                Mockito.any(Integer.class),
+                Mockito.any(Integer.class)))
+        .thenReturn(new SearchResult().setEntities(new SearchEntityArray()));
+
+    resolver.get(mockEnv).get();
+
+    // Verify domain creation
+    final DomainKey key = new DomainKey();
+    key.setId("test-id");
+    final MetadataChangeProposal domainProposal = new MetadataChangeProposal();
+    domainProposal.setEntityKeyAspect(GenericRecordUtils.serializeAspect(key));
+    domainProposal.setEntityType(Constants.DOMAIN_ENTITY_NAME);
+    DomainProperties props = new DomainProperties();
+    props.setDescription("test-description");
+    props.setName("test-name");
+    props.setCreated(new AuditStamp().setActor(TEST_ACTOR_URN).setTime(0L));
+    domainProposal.setAspectName(Constants.DOMAIN_PROPERTIES_ASPECT_NAME);
+    domainProposal.setAspect(GenericRecordUtils.serializeAspect(props));
+    domainProposal.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockClient, Mockito.times(1))
+        .ingestProposal(
+            any(),
+            Mockito.argThat(new CreateDomainProposalMatcher(domainProposal)),
+            Mockito.eq(false));
+
+    // Verify owners are added - TODO Verify the contents.
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(any(), any(), Mockito.eq(false));
+  }
+
+  @Test
+  public void testGetSuccessNoOwnersProvided() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    EntityService<?> mockService = getMockEntityService();
+    CreateDomainResolver resolver = new CreateDomainResolver(mockClient, mockService);
+
+    Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
+    Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_PARENT_DOMAIN_URN))).thenReturn(true);
+
+    // Mock the domain URN that will be returned from ingestProposal
+    Mockito.when(mockClient.ingestProposal(any(), any(), Mockito.eq(false)))
+        .thenReturn(TEST_DOMAIN_URN.toString());
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Mockito.when(
+            mockClient.filter(
+                any(),
+                Mockito.eq(Constants.DOMAIN_ENTITY_NAME),
+                Mockito.eq(
+                    DomainUtils.buildNameAndParentDomainFilter(
+                        TEST_INPUT.getName(), TEST_PARENT_DOMAIN_URN)),
+                Mockito.eq(null),
+                Mockito.any(Integer.class),
+                Mockito.any(Integer.class)))
+        .thenReturn(new SearchResult().setEntities(new SearchEntityArray()));
+
+    resolver.get(mockEnv).get();
+
+    // Verify domain creation
+    final DomainKey key = new DomainKey();
+    key.setId("test-id");
+    final MetadataChangeProposal domainProposal = new MetadataChangeProposal();
+    domainProposal.setEntityKeyAspect(GenericRecordUtils.serializeAspect(key));
+    domainProposal.setEntityType(Constants.DOMAIN_ENTITY_NAME);
+    DomainProperties props = new DomainProperties();
+    props.setDescription("test-description");
+    props.setName("test-name");
+    props.setCreated(new AuditStamp().setActor(TEST_ACTOR_URN).setTime(0L));
+    props.setParentDomain(TEST_PARENT_DOMAIN_URN);
+    domainProposal.setAspectName(Constants.DOMAIN_PROPERTIES_ASPECT_NAME);
+    domainProposal.setAspect(GenericRecordUtils.serializeAspect(props));
+    domainProposal.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockClient, Mockito.times(1))
+        .ingestProposal(
+            any(),
+            Mockito.argThat(new CreateDomainProposalMatcher(domainProposal)),
+            Mockito.eq(false));
   }
 
   @Test

--- a/datahub-web-react/src/alchemy-components/components/Select/Nested/NestedOption.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/Nested/NestedOption.tsx
@@ -105,6 +105,7 @@ export const NestedOption = <OptionType extends NestedSelectOption>({
             selectableChildren,
             areParentsSelectable,
             implicitlySelectChildren,
+            isMultiSelect: !!isMultiSelect,
             addOptions,
             removeOptions,
             setSelectedOptions,
@@ -215,6 +216,7 @@ export const NestedOption = <OptionType extends NestedSelectOption>({
                             areParentsSelectable={areParentsSelectable}
                             setSelectedOptions={setSelectedOptions}
                             implicitlySelectChildren={implicitlySelectChildren}
+                            renderCustomOptionText={renderCustomOptionText}
                         />
                     ))}
                 </ChildOptions>

--- a/datahub-web-react/src/alchemy-components/components/Select/Nested/NestedSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/Nested/NestedSelect.tsx
@@ -60,7 +60,7 @@ export const selectDefaults: SelectProps = {
     isDisabled: false,
     isReadOnly: false,
     isRequired: false,
-    isMultiSelect: false,
+    isMultiSelect: true,
     width: 255,
     height: 425,
     shouldDisplayConfirmationFooter: false,
@@ -168,7 +168,11 @@ export const NestedSelect = <OptionType extends NestedSelectOption = NestedSelec
             let newStagedOptions: OptionType[];
             if (stagedOptions.find((o) => o.value === option.value)) {
                 newStagedOptions = stagedOptions.filter((o) => o.value !== option.value);
+            } else if (!isMultiSelect) {
+                // Single selection: replace all options with just this one
+                newStagedOptions = [option];
             } else {
+                // Multi selection: add to existing options
                 newStagedOptions = [...stagedOptions, option];
             }
             setStagedOptions(newStagedOptions);
@@ -181,14 +185,23 @@ export const NestedSelect = <OptionType extends NestedSelectOption = NestedSelec
 
     const addOptions = useCallback(
         (optionsToAdd: OptionType[]) => {
-            const existingValues = new Set(stagedOptions.map((option) => option.value));
-            const filteredOptionsToAdd = optionsToAdd.filter((option) => !existingValues.has(option.value));
-            if (filteredOptionsToAdd.length) {
-                const newStagedOptions = [...stagedOptions, ...filteredOptionsToAdd];
-                setStagedOptions(newStagedOptions);
+            if (!isMultiSelect) {
+                // Single selection: take only the first option
+                const firstOption = optionsToAdd[0];
+                if (firstOption) {
+                    setStagedOptions([firstOption]);
+                }
+            } else {
+                // Multi selection: add to existing options
+                const existingValues = new Set(stagedOptions.map((option) => option.value));
+                const filteredOptionsToAdd = optionsToAdd.filter((option) => !existingValues.has(option.value));
+                if (filteredOptionsToAdd.length) {
+                    const newStagedOptions = [...stagedOptions, ...filteredOptionsToAdd];
+                    setStagedOptions(newStagedOptions);
+                }
             }
         },
-        [stagedOptions],
+        [stagedOptions, isMultiSelect],
     );
 
     const removeOptions = useCallback(

--- a/datahub-web-react/src/alchemy-components/components/Select/Nested/__tests__/useSelectOption.test.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/Nested/__tests__/useSelectOption.test.ts
@@ -16,6 +16,7 @@ const defaultProps = {
     selectableChildren: children,
     areParentsSelectable: true,
     implicitlySelectChildren: false,
+    isMultiSelect: true,
     addOptions: () => {},
     removeOptions: () => {},
     setSelectedOptions: () => {},
@@ -216,5 +217,268 @@ describe('useSelectChildren - areParentsSelectable is true & implicitlySelectChi
         expect(isImplicitlySelected).toBe(false);
         selectOption();
         expect(mockRemoveOptions).toHaveBeenCalledWith([option]);
+    });
+});
+
+describe('useSelectChildren - isMultiSelect is false (single select mode)', () => {
+    const singleSelectProps = {
+        ...defaultProps,
+        isMultiSelect: false,
+    };
+
+    it('should clear previous selections when selecting a new option', () => {
+        const mockSetSelectedOptions = vi.fn();
+        const previouslySelected = { value: '5', label: '5' };
+
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                selectedOptions: [previouslySelected],
+                setSelectedOptions: mockSetSelectedOptions,
+            }),
+        );
+
+        const { selectOption } = result.current;
+        selectOption();
+
+        // Should replace all previous selections with just the current option
+        expect(mockSetSelectedOptions).toHaveBeenCalledWith([option]);
+    });
+
+    it('should not show partial selection state when areParentsSelectable is true', () => {
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                areParentsSelectable: true,
+                selectedOptions: [children[0]], // Some children selected
+            }),
+        );
+
+        const { isPartialSelected } = result.current;
+
+        // In single select mode with areParentsSelectable=true, partial selection should be false
+        expect(isPartialSelected).toBe(false);
+    });
+
+    it('should replace selection when selecting a child option', () => {
+        const mockSetSelectedOptions = vi.fn();
+        const childOption = children[0];
+        const previouslySelected = { value: '5', label: '5' };
+
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                option: childOption,
+                selectedOptions: [previouslySelected],
+                setSelectedOptions: mockSetSelectedOptions,
+            }),
+        );
+
+        const { selectOption } = result.current;
+        selectOption();
+
+        expect(mockSetSelectedOptions).toHaveBeenCalledWith([childOption]);
+    });
+
+    it('should show implicit selection correctly even in single select mode', () => {
+        const childOption = { ...children[0], parentValue: option.value };
+
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                option: childOption,
+                selectedOptions: [option], // Parent is selected
+                implicitlySelectChildren: true,
+            }),
+        );
+
+        const { isImplicitlySelected } = result.current;
+
+        // Implicit selection logic still works in single select mode
+        // The child should appear as implicitly selected when parent is selected
+        expect(isImplicitlySelected).toBe(true);
+    });
+
+    it('should handle parent selection with areParentsSelectable=false in single select mode', () => {
+        const mockSetSelectedOptions = vi.fn();
+
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                areParentsSelectable: false,
+                setSelectedOptions: mockSetSelectedOptions,
+            }),
+        );
+
+        const { selectOption, isPartialSelected } = result.current;
+
+        expect(isPartialSelected).toBe(false);
+        selectOption();
+
+        // Should still replace selections, but only with the parent option
+        expect(mockSetSelectedOptions).toHaveBeenCalledWith([option]);
+    });
+
+    it('should handle implicit selection in single select mode', () => {
+        const mockSetSelectedOptions = vi.fn();
+        const mockRemoveOptions = vi.fn();
+
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                areParentsSelectable: true,
+                implicitlySelectChildren: true,
+                setSelectedOptions: mockSetSelectedOptions,
+                removeOptions: mockRemoveOptions,
+            }),
+        );
+
+        const { selectOption } = result.current;
+        selectOption();
+
+        // In single select mode with implicit selection, should set only the parent
+        expect(mockSetSelectedOptions).toHaveBeenCalledWith([option]);
+    });
+
+    it('should deselect when clicking already selected option in single select mode', () => {
+        const mockRemoveOptions = vi.fn();
+
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                areParentsSelectable: true,
+                implicitlySelectChildren: true,
+                selectedOptions: [option],
+                removeOptions: mockRemoveOptions,
+            }),
+        );
+
+        const { selectOption, isSelected } = result.current;
+
+        expect(isSelected).toBe(true);
+        selectOption();
+
+        // Should remove the option when it's already selected
+        expect(mockRemoveOptions).toHaveBeenCalledWith([option]);
+    });
+
+    it('should not create partial selections with child selections in single select mode', () => {
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                areParentsSelectable: false,
+                selectedOptions: [children[0]], // One child selected
+            }),
+        );
+
+        const { isPartialSelected, isSelected } = result.current;
+
+        // When areParentsSelectable is false and some children are selected,
+        // it should show as partially selected even in single select mode
+        expect(isPartialSelected).toBe(true);
+        // Parent should not be selected when only some children are selected
+        expect(isSelected).toBe(false);
+    });
+
+    it('should handle selection of parent when all children are selected in single select mode', () => {
+        const mockRemoveOptions = vi.fn();
+
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                areParentsSelectable: true,
+                selectedOptions: [...children], // All children selected
+                removeOptions: mockRemoveOptions,
+            }),
+        );
+
+        const { selectOption, isSelected, isPartialSelected } = result.current;
+
+        // In single select mode, parent should not be considered selected even if all children are
+        expect(isSelected).toBe(false);
+        expect(isPartialSelected).toBe(false);
+
+        selectOption();
+        // When all children are selected, selecting parent should remove all selections
+        expect(mockRemoveOptions).toHaveBeenCalledWith([option, ...children]);
+    });
+
+    it('should properly handle child option selection in single select mode', () => {
+        const mockSetSelectedOptions = vi.fn();
+        const childOption = children[0];
+
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                option: childOption,
+                children: [],
+                selectableChildren: [],
+                setSelectedOptions: mockSetSelectedOptions,
+            }),
+        );
+
+        const { selectOption, isSelected, isPartialSelected } = result.current;
+
+        expect(isSelected).toBe(false);
+        expect(isPartialSelected).toBe(false);
+
+        selectOption();
+        expect(mockSetSelectedOptions).toHaveBeenCalledWith([childOption]);
+    });
+
+    it('should prevent showing implicitly selected state for parents in single select mode', () => {
+        // Test the specific requirement: should not show implicitly selected parents
+        const childOption = { ...children[0], parentValue: option.value };
+
+        const { result } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                option, // Testing parent option
+                selectedOptions: [childOption], // Child is selected
+                implicitlySelectChildren: true,
+                areParentsSelectable: true,
+            }),
+        );
+
+        const { isSelected, isPartialSelected } = result.current;
+
+        // In single select mode, parent should not be implicitly selected
+        // even when child is selected and implicitlySelectChildren is true
+        expect(isSelected).toBe(false);
+        // Should show partial selection state to indicate child selection
+        expect(isPartialSelected).toBe(false); // Due to single select mode logic
+    });
+
+    it('should ensure only one selection at a time with various option types', () => {
+        const mockSetSelectedOptions = vi.fn();
+        const existingOption = { value: 'existing', label: 'Existing' };
+
+        // Test selecting parent when another option is already selected
+        const { result: parentResult } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                selectedOptions: [existingOption],
+                setSelectedOptions: mockSetSelectedOptions,
+            }),
+        );
+
+        parentResult.current.selectOption();
+        expect(mockSetSelectedOptions).toHaveBeenCalledWith([option]);
+
+        // Test selecting child when another option is already selected
+        const childOption = children[0];
+        const { result: childResult } = renderHook(() =>
+            useNestedOption({
+                ...singleSelectProps,
+                option: childOption,
+                children: [],
+                selectableChildren: [],
+                selectedOptions: [existingOption],
+                setSelectedOptions: mockSetSelectedOptions,
+            }),
+        );
+
+        childResult.current.selectOption();
+        expect(mockSetSelectedOptions).toHaveBeenCalledWith([childOption]);
     });
 });

--- a/datahub-web-react/src/app/domainV2/CreateDomainModal.tsx
+++ b/datahub-web-react/src/app/domainV2/CreateDomainModal.tsx
@@ -1,10 +1,15 @@
-import { Collapse, Form, Input, Modal, Tag, Typography, message } from 'antd';
-import React, { useState } from 'react';
+import { Collapse, Form, message } from 'antd';
+import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
+import { Label } from '@components/components/TextArea/components';
+
 import analytics, { EventType } from '@app/analytics';
+import { useUserContext } from '@app/context/useUserContext';
 import { UpdatedDomain, useDomainsContext as useDomainsContextV2 } from '@app/domainV2/DomainsContext';
-import DomainParentSelect from '@app/entityV2/shared/EntityDropdown/DomainParentSelect';
+import OwnersSection from '@app/domainV2/OwnersSection';
+import DomainSelector from '@app/entityV2/shared/DomainSelector/DomainSelector';
+import { createOwnerInputs } from '@app/entityV2/shared/utils/selectorUtils';
 import { ModalButtonContainer } from '@app/shared/button/styledComponents';
 import { validateCustomUrnId } from '@app/shared/textUtil';
 import { useEnterKeyListener } from '@app/shared/useEnterKeyListener';
@@ -12,20 +17,10 @@ import { useReloadableContext } from '@app/sharedV2/reloadableContext/hooks/useR
 import { ReloadableKeyTypeNamespace } from '@app/sharedV2/reloadableContext/types';
 import { getReloadableKeyType } from '@app/sharedV2/reloadableContext/utils';
 import { useIsNestedDomainsEnabled } from '@app/useAppConfig';
-import { Button } from '@src/alchemy-components';
+import { Button, Input, Modal, TextArea } from '@src/alchemy-components';
 
 import { useCreateDomainMutation } from '@graphql/domain.generated';
 import { DataHubPageModuleType, EntityType } from '@types';
-
-const SuggestedNamesGroup = styled.div`
-    margin-top: 8px;
-`;
-
-const ClickableTag = styled(Tag)`
-    :hover {
-        cursor: pointer;
-    }
-`;
 
 const FormItem = styled(Form.Item)`
     .ant-form-item-label {
@@ -38,16 +33,7 @@ const FormItemWithMargin = styled(FormItem)`
 `;
 
 const FormItemNoMargin = styled(FormItem)`
-    margin-bottom: 0;
-`;
-
-const FormItemLabel = styled(Typography.Text)`
-    font-weight: 600;
-    color: #373d44;
-`;
-
-const AdvancedLabel = styled(Typography.Text)`
-    color: #373d44;
+    margin-bottom: 0px;
 `;
 
 type Props = {
@@ -60,8 +46,6 @@ type Props = {
         parentDomain?: string,
     ) => void;
 };
-
-const SUGGESTED_DOMAIN_NAMES = ['Engineering', 'Marketing', 'Sales', 'Product'];
 
 const ID_FIELD_NAME = 'id';
 const NAME_FIELD_NAME = 'name';
@@ -76,10 +60,23 @@ export default function CreateDomainModal({ onClose, onCreate }: Props) {
     );
     const [createButtonEnabled, setCreateButtonEnabled] = useState(false);
     const [form] = Form.useForm();
+    const [selectedOwnerUrns, setSelectedOwnerUrns] = useState<string[]>([]);
+    const { user } = useUserContext();
+
+    // Simply provide current user as placeholder - OwnersSection will handle auto-selection
+    const defaultOwners = user ? [user] : [];
+
+    // Stable callback for setting owner URNs
+    const handleSetSelectedOwnerUrns = useCallback((ownerUrns: React.SetStateAction<string[]>) => {
+        setSelectedOwnerUrns(ownerUrns);
+    }, []);
 
     const { reloadByKeyType } = useReloadableContext();
 
     const onCreateDomain = () => {
+        // Create owner input objects from selected owner URNs using utility
+        const ownerInputs = createOwnerInputs(selectedOwnerUrns);
+
         createDomainMutation({
             variables: {
                 input: {
@@ -87,6 +84,7 @@ export default function CreateDomainModal({ onClose, onCreate }: Props) {
                     name: form.getFieldValue(NAME_FIELD_NAME),
                     description: form.getFieldValue(DESCRIPTION_FIELD_NAME),
                     parentDomain: selectedParentUrn || undefined,
+                    owners: ownerInputs,
                 },
             },
         })
@@ -169,86 +167,67 @@ export default function CreateDomainModal({ onClose, onCreate }: Props) {
                     setCreateButtonEnabled(!form.getFieldsError().some((field) => field.errors.length > 0));
                 }}
             >
-                <FormItemWithMargin label={<FormItemLabel>Name</FormItemLabel>}>
-                    <FormItemNoMargin
-                        name={NAME_FIELD_NAME}
-                        rules={[
-                            {
-                                required: true,
-                                message: 'Enter a Domain name.',
-                            },
-                            { whitespace: true },
-                            { min: 1, max: 150 },
-                        ]}
-                        hasFeedback
-                    >
-                        <Input data-testid="create-domain-name" placeholder="A name for your domain" />
-                    </FormItemNoMargin>
-                    <SuggestedNamesGroup>
-                        {SUGGESTED_DOMAIN_NAMES.map((name) => {
-                            return (
-                                <ClickableTag
-                                    key={name}
-                                    onClick={() => {
-                                        form.setFieldsValue({
-                                            name,
-                                        });
-                                        setCreateButtonEnabled(true);
-                                    }}
-                                >
-                                    {name}
-                                </ClickableTag>
-                            );
-                        })}
-                    </SuggestedNamesGroup>
+                <FormItemWithMargin
+                    name={NAME_FIELD_NAME}
+                    rules={[
+                        {
+                            required: true,
+                            message: 'Enter a Domain name.',
+                        },
+                        { whitespace: true },
+                        { min: 1, max: 150 },
+                    ]}
+                    hasFeedback
+                >
+                    <Input label="Name" data-testid="create-domain-name" placeholder="A name for your domain" />
                 </FormItemWithMargin>
                 <FormItemWithMargin
-                    label={<FormItemLabel>Description</FormItemLabel>}
-                    help="You can always change the description later."
+                    name={DESCRIPTION_FIELD_NAME}
+                    rules={[{ whitespace: true }, { min: 1, max: 500 }]}
+                    hasFeedback
                 >
-                    <FormItemNoMargin
-                        name={DESCRIPTION_FIELD_NAME}
-                        rules={[{ whitespace: true }, { min: 1, max: 500 }]}
-                        hasFeedback
-                    >
-                        <Input.TextArea
-                            placeholder="A description for your domain"
-                            data-testid="create-domain-description"
-                        />
-                    </FormItemNoMargin>
+                    <TextArea
+                        label="Description"
+                        placeholder="A description for your domain"
+                        data-testid="create-domain-description"
+                    />
                 </FormItemWithMargin>
                 {isNestedDomainsEnabled && (
-                    <FormItemWithMargin label={<FormItemLabel>Parent (optional)</FormItemLabel>}>
-                        <DomainParentSelect
-                            selectedParentUrn={selectedParentUrn}
-                            setSelectedParentUrn={setSelectedParentUrn}
+                    <FormItemWithMargin>
+                        <Label>Parent Domains</Label>
+                        <DomainSelector
+                            selectedDomains={selectedParentUrn ? [selectedParentUrn] : []}
+                            onDomainsChange={(selectedDomainUrns) => setSelectedParentUrn(selectedDomainUrns[0] || '')}
+                            placeholder="Select parent domain"
+                            label=""
+                            isMultiSelect={false}
                         />
                     </FormItemWithMargin>
                 )}
+                {/* Owners Section */}
+                <FormItemNoMargin>
+                    <OwnersSection
+                        selectedOwnerUrns={selectedOwnerUrns}
+                        setSelectedOwnerUrns={handleSetSelectedOwnerUrns}
+                        defaultOwners={defaultOwners}
+                    />
+                </FormItemNoMargin>
                 <Collapse ghost>
-                    <Collapse.Panel header={<AdvancedLabel>Advanced Options</AdvancedLabel>} key="1">
+                    <Collapse.Panel header={<Label>Advanced Options</Label>} key="1">
                         <FormItemWithMargin
-                            label={<Typography.Text strong>Domain Id</Typography.Text>}
-                            help="By default, a random UUID will be generated to uniquely identify this domain. If
-                                you'd like to provide a custom id instead to more easily keep track of this domain,
-                                you may provide it here. Be careful, you cannot easily change the domain id after
-                                creation."
+                            name={ID_FIELD_NAME}
+                            rules={[
+                                () => ({
+                                    validator(_, value) {
+                                        if (value && validateCustomUrnId(value)) {
+                                            return Promise.resolve();
+                                        }
+                                        return Promise.reject(new Error('Please enter a valid Domain id'));
+                                    },
+                                }),
+                            ]}
                         >
-                            <FormItemNoMargin
-                                name={ID_FIELD_NAME}
-                                rules={[
-                                    () => ({
-                                        validator(_, value) {
-                                            if (value && validateCustomUrnId(value)) {
-                                                return Promise.resolve();
-                                            }
-                                            return Promise.reject(new Error('Please enter a valid Domain id'));
-                                        },
-                                    }),
-                                ]}
-                            >
-                                <Input data-testid="create-domain-id" placeholder="engineering" />
-                            </FormItemNoMargin>
+                            <Input label="Custom Id" data-testid="create-domain-id" placeholder="engineering" />
                         </FormItemWithMargin>
                     </Collapse.Panel>
                 </Collapse>

--- a/datahub-web-react/src/app/domainV2/OwnersSection.tsx
+++ b/datahub-web-react/src/app/domainV2/OwnersSection.tsx
@@ -1,0 +1,61 @@
+import { Text } from '@components';
+import React from 'react';
+import styled from 'styled-components';
+
+import { ActorsSearchSelect } from '@app/entityV2/shared/EntitySearchSelect/ActorsSearchSelect';
+
+import { CorpGroup, CorpUser, OwnerEntityType } from '@types';
+
+// Interface for pending owner
+export interface PendingOwner {
+    ownerUrn: string;
+    ownerEntityType: OwnerEntityType;
+    ownershipTypeUrn: string;
+}
+
+const SectionContainer = styled.div`
+    margin-bottom: 24px;
+`;
+
+const SectionHeader = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+`;
+
+const FormSection = styled.div`
+    margin-bottom: 16px;
+`;
+
+// Owners section props
+interface Props {
+    defaultOwners?: (CorpGroup | CorpUser)[];
+    selectedOwnerUrns: string[];
+    setSelectedOwnerUrns: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+/**
+ * Component for owner selection and management using standard components
+ * The goal is to replace sharedV2/owners/OwnersSection.tsx with this component.
+ */
+const OwnersSection = ({ defaultOwners: placeholderOwners, selectedOwnerUrns, setSelectedOwnerUrns }: Props) => {
+    return (
+        <SectionContainer>
+            <SectionHeader>
+                <Text>Add Owners</Text>
+            </SectionHeader>
+            <FormSection>
+                <ActorsSearchSelect
+                    selectedActorUrns={selectedOwnerUrns}
+                    onUpdate={(selectedActors) => setSelectedOwnerUrns(selectedActors.map((actor) => actor.urn))}
+                    placeholder="Search for users or groups"
+                    defaultActors={placeholderOwners}
+                    width="full"
+                />
+            </FormSection>
+        </SectionContainer>
+    );
+};
+
+export default OwnersSection;

--- a/datahub-web-react/src/app/domainV2/nestedDomains/DomainsSidebarHeader.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/DomainsSidebarHeader.tsx
@@ -43,7 +43,12 @@ export default function DomainsSidebarHeader() {
                     data-testid="sidebar-create-domain-button"
                 />
             </Tooltip>
-            {isCreatingDomain && <CreateDomainModal onClose={() => setIsCreatingDomain(false)} />}
+            {isCreatingDomain && (
+                <CreateDomainModal
+                    onClose={() => setIsCreatingDomain(false)}
+                    onCreate={() => setIsCreatingDomain(false)}
+                />
+            )}
         </Wrapper>
     );
 }

--- a/datahub-web-react/src/app/entityV2/group/utils.ts
+++ b/datahub-web-react/src/app/entityV2/group/utils.ts
@@ -1,0 +1,8 @@
+import { CorpGroup, Entity, EntityType } from '@src/types.generated';
+
+/**
+ * Type guard for groups
+ */
+export function isCorpGroup(entity?: Entity | null | undefined): entity is CorpGroup {
+    return !!entity && entity.type === EntityType.CorpGroup;
+}

--- a/datahub-web-react/src/app/entityV2/shared/DomainSelector/DomainSelector.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/DomainSelector/DomainSelector.tsx
@@ -1,0 +1,239 @@
+import { debounce } from 'lodash';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { InfiniteScrollNestedSelect } from '@app/entityV2/shared/DomainSelector/InfiniteScrollNestedSelect';
+import useInfiniteScrollDomains, {
+    getDomainSelectorScrollInput,
+} from '@app/entityV2/shared/DomainSelector/useInfiniteScrollDomains';
+import {
+    buildEntityCache,
+    entitiesToNestedSelectOptions,
+    isEntityResolutionRequired,
+    mergeSelectedNestedOptions,
+} from '@app/entityV2/shared/utils/selectorUtils';
+import { DEBOUNCE_SEARCH_MS } from '@app/shared/constants';
+import { NestedSelectOption } from '@src/alchemy-components/components/Select/Nested/types';
+import { useEntityRegistryV2 } from '@src/app/useEntityRegistry';
+import { useGetEntitiesLazyQuery } from '@src/graphql/entity.generated';
+import {
+    useGetAutoCompleteMultipleResultsLazyQuery,
+    useScrollAcrossEntitiesLazyQuery,
+} from '@src/graphql/search.generated';
+import { Entity, EntityType } from '@src/types.generated';
+
+type DomainSelectorProps = {
+    selectedDomains: string[];
+    onDomainsChange: (domainUrns: string[]) => void;
+    placeholder?: string;
+    label?: string;
+    isMultiSelect?: boolean;
+};
+
+/**
+ * Standalone domain selector component that doesn't rely on Ant Design form state
+ * Supports both single and multiple domain selection based on isMultiSelect prop
+ * Works with URN strings instead of Domain objects for simpler integration
+ *
+ * Features:
+ * - Infinite scroll support at root level for domains without parents
+ * - Paginated loading of nested children using scrollAcrossEntities (no 1000 limit)
+ * - Debounced search with autocomplete
+ * - Entity caching for selected domains
+ */
+const DomainSelector: React.FC<DomainSelectorProps> = ({
+    selectedDomains,
+    onDomainsChange,
+    placeholder = 'Select domains',
+    label = 'Domains',
+    isMultiSelect = false,
+}) => {
+    const entityRegistry = useEntityRegistryV2();
+    const [useSearch, setUseSearch] = useState(false);
+    const [entityCache, setEntityCache] = useState<Map<string, Entity>>(new Map());
+
+    // Entity hydration for selected domains
+    const [getEntities, { data: resolvedEntitiesData }] = useGetEntitiesLazyQuery();
+
+    // Bootstrap by resolving all URNs that are not in the cache yet
+    useEffect(() => {
+        if (selectedDomains.length > 0 && isEntityResolutionRequired(selectedDomains, entityCache)) {
+            getEntities({ variables: { urns: selectedDomains } });
+        }
+    }, [selectedDomains, entityCache, getEntities]);
+
+    // Build cache from resolved entities
+    useEffect(() => {
+        if (resolvedEntitiesData && resolvedEntitiesData.entities?.length) {
+            // Should be a safe cast since we're only querying for entities
+            const entities: Entity[] = (resolvedEntitiesData?.entities as Entity[]) || [];
+            setEntityCache(buildEntityCache(entities));
+        }
+    }, [resolvedEntitiesData]);
+
+    const [autoComplete, { data: autoCompleteData }] = useGetAutoCompleteMultipleResultsLazyQuery();
+
+    // Infinite scroll for root level domains (domains without parents)
+    const {
+        domains: rootDomains,
+        loading: rootDomainsLoading,
+        hasMoreDomains,
+        scrollRef,
+    } = useInfiniteScrollDomains({
+        skip: useSearch, // Skip infinite scroll when in search mode
+    });
+
+    // Convert selected domain URNs to NestedSelectOption format using utility
+    // Use useMemo to prevent unnecessary recalculations and ensure NestedSelect properly syncs
+    const initialOptions = useMemo(() => {
+        return entitiesToNestedSelectOptions(selectedDomains, entityCache, entityRegistry);
+    }, [selectedDomains, entityCache, entityRegistry]);
+
+    const [childOptions, setChildOptions] = useState<NestedSelectOption[]>([]);
+    const [loadedChildUrns, setLoadedChildUrns] = useState<Set<string>>(new Set());
+
+    // Track scroll state per parent domain for nested infinite scroll
+    const scrollStateRef = useRef<Map<string, { scrollId: string | null; isComplete: boolean }>>(new Map());
+
+    const [scrollNestedDomains, { data: nestedScrollData }] = useScrollAcrossEntitiesLazyQuery({
+        fetchPolicy: 'cache-and-network',
+        notifyOnNetworkStatusChange: true,
+    });
+
+    // Process nested scroll results
+    useEffect(() => {
+        if (nestedScrollData?.scrollAcrossEntities?.searchResults) {
+            const { searchResults: results, nextScrollId } = nestedScrollData.scrollAcrossEntities;
+            const childOptionsToAdd: NestedSelectOption[] = [];
+
+            results.forEach((result) => {
+                const domain = result.entity;
+                // Only add if we haven't loaded this URN yet and it's a domain
+                if (domain.type === EntityType.Domain && !loadedChildUrns.has(domain.urn)) {
+                    childOptionsToAdd.push({
+                        value: domain.urn,
+                        label: entityRegistry.getDisplayName(domain.type, domain),
+                        isParent: !!(domain as any)?.children?.total,
+                        parentValue: (domain as any)?.parentDomains?.domains?.[0]?.urn,
+                        entity: domain,
+                    });
+                }
+            });
+
+            if (childOptionsToAdd.length > 0) {
+                setChildOptions((existingOptions) => [...existingOptions, ...childOptionsToAdd]);
+                setLoadedChildUrns((prev) => {
+                    const updated = new Set(prev);
+                    childOptionsToAdd.forEach((opt) => updated.add(opt.value));
+                    return updated;
+                });
+            }
+
+            // Check if we need to continue fetching for this parent
+            if (nextScrollId && results.length > 0) {
+                // Find the parent domain from the first result
+                const firstResult = results[0]?.entity;
+                const parentUrn = (firstResult as any)?.parentDomains?.domains?.[0]?.urn;
+
+                if (parentUrn) {
+                    // Update scroll state and continue fetching
+                    scrollStateRef.current.set(parentUrn, { scrollId: nextScrollId, isComplete: false });
+                    scrollNestedDomains({
+                        variables: getDomainSelectorScrollInput(parentUrn, nextScrollId),
+                    });
+                }
+            } else if (results.length > 0) {
+                // Mark this parent as complete
+                const firstResult = results[0]?.entity;
+                const parentUrn = (firstResult as any)?.parentDomains?.domains?.[0]?.urn;
+                if (parentUrn) {
+                    scrollStateRef.current.set(parentUrn, { scrollId: null, isComplete: true });
+                }
+            }
+        }
+    }, [nestedScrollData, entityRegistry, loadedChildUrns, scrollNestedDomains]);
+
+    // Root level options from infinite scroll (already in NestedSelectOption format)
+    const options = rootDomains;
+
+    const autoCompleteOptions =
+        autoCompleteData?.autoCompleteForMultiple?.suggestions?.flatMap((s) =>
+            s.entities.map((domain) => ({
+                value: domain.urn,
+                label: entityRegistry.getDisplayName(domain.type, domain),
+                id: domain.urn,
+                entity: domain,
+            })),
+        ) || [];
+
+    function handleLoad(option: NestedSelectOption) {
+        const parentUrn = option.value;
+
+        // Check if we've already loaded this parent's children
+        const scrollState = scrollStateRef.current.get(parentUrn);
+        if (scrollState?.isComplete) {
+            return; // Already loaded all children
+        }
+
+        // Start fetching children using scrollAcrossEntities for pagination support
+        // This removes the 1000 child limit and fetches in batches
+        scrollStateRef.current.set(parentUrn, { scrollId: null, isComplete: false });
+        scrollNestedDomains({
+            variables: getDomainSelectorScrollInput(parentUrn, null),
+        });
+    }
+
+    // Debounced search handler to avoid querying on every keystroke
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const handleSearch = useCallback(
+        debounce((query: string) => {
+            if (query) {
+                autoComplete({ variables: { input: { query, types: [EntityType.Domain] } } });
+                setUseSearch(true);
+            } else {
+                setUseSearch(false);
+            }
+        }, DEBOUNCE_SEARCH_MS),
+        [autoComplete],
+    );
+
+    function handleUpdate(values: NestedSelectOption[]) {
+        if (values.length) {
+            const domainUrnsToUpdate = values.map((v) => v.value);
+            onDomainsChange(domainUrnsToUpdate);
+        } else {
+            onDomainsChange([]);
+        }
+    }
+
+    // Merge options to ensure selected domains remain visible
+    const baseOptions = [...options, ...childOptions].sort((a, b) => a.label.localeCompare(b.label));
+    const searchOptions = [...autoCompleteOptions].sort((a, b) => a.label.localeCompare(b.label));
+
+    const defaultOptions = mergeSelectedNestedOptions(baseOptions, initialOptions);
+    const searchOptionsWithSelected = mergeSelectedNestedOptions(searchOptions, initialOptions);
+
+    return (
+        <InfiniteScrollNestedSelect
+            label={label}
+            placeholder={placeholder}
+            searchPlaceholder="Search all domains..."
+            options={useSearch ? searchOptionsWithSelected : defaultOptions}
+            initialValues={initialOptions}
+            loadData={handleLoad}
+            onSearch={handleSearch}
+            onUpdate={handleUpdate}
+            loading={rootDomainsLoading}
+            hasMore={hasMoreDomains && !useSearch}
+            scrollRef={scrollRef}
+            width="full"
+            isMultiSelect={isMultiSelect}
+            showSearch
+            implicitlySelectChildren={false}
+            areParentsSelectable
+            shouldAlwaysSyncParentValues
+            hideParentCheckbox={false}
+        />
+    );
+};
+
+export default DomainSelector;

--- a/datahub-web-react/src/app/entityV2/shared/DomainSelector/InfiniteScrollNestedSelect.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/DomainSelector/InfiniteScrollNestedSelect.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Loader } from '@src/alchemy-components/components/Loader/Loader';
+import { NestedSelect, SelectProps } from '@src/alchemy-components/components/Select/Nested/NestedSelect';
+import { NestedSelectOption } from '@src/alchemy-components/components/Select/Nested/types';
+
+const ScrollTrigger = styled.div`
+    height: 1px;
+    width: 100%;
+    opacity: 0;
+    pointer-events: none;
+`;
+
+const LoadingContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 12px;
+    border-top: 1px solid #f0f0f0;
+    background: white;
+`;
+
+export interface InfiniteScrollNestedSelectProps<OptionType extends NestedSelectOption = NestedSelectOption>
+    extends Omit<SelectProps<OptionType>, 'options'> {
+    options: OptionType[];
+    loading?: boolean;
+    hasMore?: boolean;
+    scrollRef?: ((node?: Element | null) => void) | React.RefObject<HTMLDivElement>;
+}
+
+/**
+ * Enhanced NestedSelect with infinite scroll capability
+ * Adds a scroll trigger element and loading indicator for infinite scroll functionality
+ */
+export function InfiniteScrollNestedSelect<OptionType extends NestedSelectOption = NestedSelectOption>({
+    options,
+    loading = false,
+    hasMore = false,
+    scrollRef,
+    ...selectProps
+}: InfiniteScrollNestedSelectProps<OptionType>) {
+    // Render the scroll trigger and loading indicator as additional options
+    const enhancedOptions = React.useMemo(() => {
+        const baseOptions = [...options];
+
+        // Add scroll trigger as the last option if we have more data to load
+        if (hasMore && !loading) {
+            baseOptions.push({
+                value: '__scroll_trigger__',
+                label: '',
+                id: '__scroll_trigger__',
+                isScrollTrigger: true,
+            } as unknown as OptionType);
+        }
+
+        // Add loading indicator if currently loading
+        if (loading && options.length > 0) {
+            baseOptions.push({
+                value: '__loading__',
+                label: '',
+                id: '__loading__',
+                isLoadingIndicator: true,
+            } as unknown as OptionType);
+        }
+
+        return baseOptions;
+    }, [options, hasMore, loading]);
+
+    const renderCustomOptionText = React.useCallback(
+        (option: OptionType) => {
+            // Handle scroll trigger
+            if ((option as any).isScrollTrigger) {
+                // Handle both callback ref and RefObject
+                const refProp = typeof scrollRef === 'function' ? { ref: scrollRef } : { ref: scrollRef };
+                return <ScrollTrigger {...refProp} />;
+            }
+
+            // Handle loading indicator
+            if ((option as any).isLoadingIndicator) {
+                return (
+                    <LoadingContainer>
+                        <Loader size="sm" />
+                    </LoadingContainer>
+                );
+            }
+
+            // Use parent's custom renderer if provided
+            if (selectProps.renderCustomOptionText) {
+                return selectProps.renderCustomOptionText(option);
+            }
+
+            // Default rendering
+            return option.label;
+        },
+        [scrollRef, selectProps],
+    );
+
+    return <NestedSelect {...selectProps} options={enhancedOptions} renderCustomOptionText={renderCustomOptionText} />;
+}

--- a/datahub-web-react/src/app/entityV2/shared/DomainSelector/__tests__/useInfiniteScrollDomains.test.ts
+++ b/datahub-web-react/src/app/entityV2/shared/DomainSelector/__tests__/useInfiniteScrollDomains.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    DOMAIN_SELECTOR_COUNT,
+    getDomainSelectorScrollInput,
+} from '@app/entityV2/shared/DomainSelector/useInfiniteScrollDomains';
+import { EntityType, FilterOperator, SortOrder } from '@src/types.generated';
+
+/**
+ * Unit tests for useInfiniteScrollDomains utility functions
+ * Testing the helper function getDomainSelectorScrollInput which generates
+ * the GraphQL query input for fetching domains with infinite scroll support
+ */
+describe('getDomainSelectorScrollInput', () => {
+    it('should create input for root domains (no parent)', () => {
+        const input = getDomainSelectorScrollInput(null, null);
+
+        expect(input).toEqual({
+            input: {
+                scrollId: null,
+                query: '*',
+                types: [EntityType.Domain],
+                orFilters: [{ and: [{ field: 'parentDomain', condition: FilterOperator.Exists, negated: true }] }],
+                count: DOMAIN_SELECTOR_COUNT,
+                sortInput: {
+                    sortCriteria: [{ field: '_entityName', sortOrder: SortOrder.Ascending }],
+                },
+                searchFlags: { skipCache: true },
+            },
+        });
+    });
+
+    it('should create input with parent domain filter', () => {
+        const parentUrn = 'urn:li:domain:engineering';
+        const input = getDomainSelectorScrollInput(parentUrn, null);
+
+        expect(input).toEqual({
+            input: {
+                scrollId: null,
+                query: '*',
+                types: [EntityType.Domain],
+                orFilters: [{ and: [{ field: 'parentDomain', values: [parentUrn] }] }],
+                count: DOMAIN_SELECTOR_COUNT,
+                sortInput: {
+                    sortCriteria: [{ field: '_entityName', sortOrder: SortOrder.Ascending }],
+                },
+                searchFlags: { skipCache: true },
+            },
+        });
+    });
+
+    it('should include scrollId when provided', () => {
+        const scrollId = 'scroll-123';
+        const input = getDomainSelectorScrollInput(null, scrollId);
+
+        expect(input.input.scrollId).toBe(scrollId);
+    });
+
+    it('should use correct count value', () => {
+        const input = getDomainSelectorScrollInput(null, null);
+
+        expect(input.input.count).toBe(DOMAIN_SELECTOR_COUNT);
+        expect(DOMAIN_SELECTOR_COUNT).toBe(2);
+    });
+
+    it('should set correct query and types', () => {
+        const input = getDomainSelectorScrollInput(null, null);
+
+        expect(input.input.query).toBe('*');
+        expect(input.input.types).toEqual([EntityType.Domain]);
+    });
+
+    it('should enable cache skipping', () => {
+        const input = getDomainSelectorScrollInput(null, null);
+
+        expect(input.input.searchFlags).toEqual({ skipCache: true });
+    });
+
+    it('should sort by entity name in ascending order', () => {
+        const input = getDomainSelectorScrollInput(null, null);
+
+        expect(input.input.sortInput).toEqual({
+            sortCriteria: [{ field: '_entityName', sortOrder: SortOrder.Ascending }],
+        });
+    });
+
+    it('should handle multiple parent domains correctly', () => {
+        const parentUrn1 = 'urn:li:domain:engineering';
+        const parentUrn2 = 'urn:li:domain:marketing';
+
+        const input1 = getDomainSelectorScrollInput(parentUrn1, null);
+        const input2 = getDomainSelectorScrollInput(parentUrn2, null);
+
+        expect(input1.input.orFilters).toEqual([{ and: [{ field: 'parentDomain', values: [parentUrn1] }] }]);
+        expect(input2.input.orFilters).toEqual([{ and: [{ field: 'parentDomain', values: [parentUrn2] }] }]);
+    });
+
+    it('should handle both parent domain and scrollId together', () => {
+        const parentUrn = 'urn:li:domain:engineering';
+        const scrollId = 'scroll-456';
+
+        const input = getDomainSelectorScrollInput(parentUrn, scrollId);
+
+        expect(input.input.scrollId).toBe(scrollId);
+        expect(input.input.orFilters).toEqual([{ and: [{ field: 'parentDomain', values: [parentUrn] }] }]);
+    });
+
+    it('should create different filters for root vs child domains', () => {
+        const rootInput = getDomainSelectorScrollInput(null, null);
+        const childInput = getDomainSelectorScrollInput('urn:li:domain:parent', null);
+
+        // Root domains: filter where parentDomain does NOT exist
+        expect(rootInput.input.orFilters).toEqual([
+            { and: [{ field: 'parentDomain', condition: FilterOperator.Exists, negated: true }] },
+        ]);
+
+        // Child domains: filter where parentDomain equals specific value
+        expect(childInput.input.orFilters).toEqual([
+            { and: [{ field: 'parentDomain', values: ['urn:li:domain:parent'] }] },
+        ]);
+    });
+
+    it('should maintain immutability - separate calls return separate objects', () => {
+        const input1 = getDomainSelectorScrollInput(null, null);
+        const input2 = getDomainSelectorScrollInput(null, null);
+
+        expect(input1).not.toBe(input2);
+        expect(input1.input).not.toBe(input2.input);
+        expect(input1).toEqual(input2);
+    });
+});

--- a/datahub-web-react/src/app/entityV2/shared/DomainSelector/useInfiniteScrollDomains.ts
+++ b/datahub-web-react/src/app/entityV2/shared/DomainSelector/useInfiniteScrollDomains.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import { ENTITY_NAME_FIELD } from '@app/searchV2/context/constants';
+import { NestedSelectOption } from '@src/alchemy-components/components/Select/Nested/types';
+import { useEntityRegistryV2 } from '@src/app/useEntityRegistry';
+import { useScrollAcrossEntitiesQuery } from '@src/graphql/search.generated';
+import { Entity, EntityType, FilterOperator, SortOrder } from '@src/types.generated';
+
+export const DOMAIN_SELECTOR_COUNT = 2;
+
+/**
+ * Generates the GraphQL scroll input for fetching domains with pagination
+ * Used for both root-level and nested domain fetching
+ *
+ * @param parentDomain - URN of parent domain (null for root domains)
+ * @param scrollId - Cursor for pagination (null for first page)
+ */
+export function getDomainSelectorScrollInput(parentDomain: string | null, scrollId: string | null) {
+    return {
+        input: {
+            scrollId,
+            query: '*',
+            types: [EntityType.Domain],
+            orFilters: parentDomain
+                ? [{ and: [{ field: 'parentDomain', values: [parentDomain] }] }]
+                : [{ and: [{ field: 'parentDomain', condition: FilterOperator.Exists, negated: true }] }],
+            count: DOMAIN_SELECTOR_COUNT,
+            sortInput: {
+                sortCriteria: [{ field: ENTITY_NAME_FIELD, sortOrder: SortOrder.Ascending }],
+            },
+            searchFlags: { skipCache: true },
+        },
+    };
+}
+
+interface Props {
+    parentDomain?: string;
+    skip?: boolean;
+}
+
+/**
+ * Custom hook for infinite scroll domains specifically adapted for DomainSelector
+ * Returns NestedSelectOption format domains and intersection observer ref
+ */
+export default function useInfiniteScrollDomains({ parentDomain, skip }: Props) {
+    const entityRegistry = useEntityRegistryV2();
+    const [hasInitialized, setHasInitialized] = useState(false);
+    const [domains, setDomains] = useState<Entity[]>([]);
+    const [domainsUrnsSet, setDomainsUrnsSet] = useState<Set<string>>(new Set());
+    const [scrollId, setScrollId] = useState<string | null>(null);
+    const [hasMoreDomains, setHasMoreDomains] = useState(true);
+
+    const {
+        data: scrollData,
+        loading,
+        error,
+        refetch,
+    } = useScrollAcrossEntitiesQuery({
+        variables: {
+            ...getDomainSelectorScrollInput(parentDomain || null, scrollId),
+        },
+        skip,
+        notifyOnNetworkStatusChange: true,
+        fetchPolicy: 'cache-and-network',
+    });
+
+    // Handle initial data and updates from scroll
+    useEffect(() => {
+        if (scrollData?.scrollAcrossEntities?.searchResults) {
+            const newResults =
+                scrollData.scrollAcrossEntities.searchResults
+                    .filter((r) => !domainsUrnsSet.has(r.entity.urn))
+                    .map((r) => r.entity)
+                    .filter((e) => e.type === EntityType.Domain) || [];
+
+            if (newResults.length > 0) {
+                setDomains((currDomains) => [...currDomains, ...newResults]);
+                setDomainsUrnsSet((currSet) => {
+                    const newSet = new Set(currSet);
+                    newResults.forEach((r) => newSet.add(r.urn));
+                    return newSet;
+                });
+            }
+
+            // Check if we have more domains to load
+            const nextScrollId = scrollData.scrollAcrossEntities?.nextScrollId;
+            setHasMoreDomains(!!nextScrollId);
+            setHasInitialized(true);
+        }
+    }, [scrollData, domainsUrnsSet]);
+
+    const nextScrollId = scrollData?.scrollAcrossEntities?.nextScrollId;
+
+    // Intersection observer for infinite scroll
+    const [scrollRef, inView] = useInView({ triggerOnce: false, threshold: 0.1 });
+
+    // Trigger loading more domains when scroll ref comes into view
+    useEffect(() => {
+        if (!loading && nextScrollId && scrollId !== nextScrollId && inView && hasMoreDomains) {
+            setScrollId(nextScrollId);
+        }
+    }, [inView, nextScrollId, scrollId, loading, hasMoreDomains]);
+
+    // Convert domains to NestedSelectOption format
+    const nestedSelectOptions = useMemo((): NestedSelectOption[] => {
+        return domains.map((domain) => ({
+            value: domain.urn,
+            label: entityRegistry.getDisplayName(domain.type, domain),
+            id: domain.urn,
+            isParent: !!(domain as any)?.children?.total,
+            parentValue: (domain as any)?.parentDomains?.domains?.[0]?.urn,
+            entity: domain,
+        }));
+    }, [domains, entityRegistry]);
+
+    // Function to manually load more domains (can be used for refresh)
+    const loadMoreDomains = useCallback(() => {
+        if (!loading && hasMoreDomains && nextScrollId) {
+            setScrollId(nextScrollId);
+        }
+    }, [loading, hasMoreDomains, nextScrollId]);
+
+    // Reset function to clear all data and start fresh
+    const resetDomains = useCallback(() => {
+        setDomains([]);
+        setDomainsUrnsSet(new Set());
+        setScrollId(null);
+        setHasInitialized(false);
+        setHasMoreDomains(true);
+    }, []);
+
+    return {
+        domains: nestedSelectOptions,
+        rawDomains: domains,
+        hasInitialized,
+        loading,
+        error,
+        hasMoreDomains,
+        refetch,
+        scrollRef,
+        loadMoreDomains,
+        resetDomains,
+    };
+}

--- a/datahub-web-react/src/app/entityV2/shared/EntitySearchSelect/ActorsSearchSelect.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/EntitySearchSelect/ActorsSearchSelect.tsx
@@ -1,0 +1,242 @@
+import { Avatar, Text } from '@components';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import { OptionType } from '@components/components/AutoComplete/types';
+
+import {
+    ActorEntity,
+    filterActors,
+    getActorEmail,
+    getActorPictureLink,
+    resolveActorsFromUrns,
+} from '@app/entityV2/shared/utils/actorUtils';
+import { deduplicateEntities, entitiesToSelectOptions } from '@app/entityV2/shared/utils/selectorUtils';
+import { useGetRecommendations } from '@app/shared/recommendation';
+import { SimpleSelect } from '@src/alchemy-components/components/Select/SimpleSelect';
+import EntityIcon from '@src/app/searchV2/autoCompleteV2/components/icon/EntityIcon';
+import { useEntityRegistryV2 } from '@src/app/useEntityRegistry';
+
+import { useGetAutoCompleteMultipleResultsLazyQuery } from '@graphql/search.generated';
+import { Entity, EntityType } from '@types';
+
+const IconAndNameContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    align-items: center;
+`;
+
+const IconWrapper = styled.div`
+    display: flex;
+    align-items: center;
+
+    & .ant-image {
+        display: flex;
+        align-items: center;
+    }
+`;
+
+const TitleContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+export interface ActorsSearchSelectProps {
+    selectedActorUrns: string[];
+    onUpdate: (selectedActors: ActorEntity[]) => void;
+    placeholder?: string;
+    defaultActors?: ActorEntity[];
+    isDisabled?: boolean;
+    width?: number | 'full' | 'fit-content';
+    showSearch?: boolean;
+}
+
+/**
+ * A specialized search and selection component for actors (CorpUser and CorpGroup entities).
+ * Built on top of SimpleSelect with actor-specific features like recommendations,
+ * avatar rendering, and placeholder support.
+ *
+ * TODO: Support resolving selected entities from selectedActorUrns on initial render.
+ */
+export const ActorsSearchSelect: React.FC<ActorsSearchSelectProps> = ({
+    selectedActorUrns,
+    onUpdate,
+    placeholder = 'Search for users or groups',
+    defaultActors: placeholderActors,
+    isDisabled = false,
+    width = 'full',
+    showSearch = true,
+}) => {
+    const entityRegistry = useEntityRegistryV2();
+    const [selectedActorEntities, setSelectedActorEntities] = useState<ActorEntity[]>([]);
+    const hasAutoSelectedRef = useRef(false);
+
+    // Auto-select placeholder actors ONLY ONCE on initial render when no actors are selected
+    useEffect(() => {
+        if (
+            placeholderActors &&
+            placeholderActors.length > 0 &&
+            !hasAutoSelectedRef.current &&
+            selectedActorUrns.length === 0
+        ) {
+            onUpdate(placeholderActors);
+            hasAutoSelectedRef.current = true;
+        }
+    }, [placeholderActors, selectedActorUrns.length, onUpdate]);
+
+    // Autocomplete query for actors (CorpUser and CorpGroup types)
+    const [autoCompleteQuery, { data: autocompleteData, loading: searchLoading }] =
+        useGetAutoCompleteMultipleResultsLazyQuery({
+            fetchPolicy: 'no-cache',
+        });
+
+    const { recommendedData, loading: recommendationsLoading } = useGetRecommendations([
+        EntityType.CorpGroup,
+        EntityType.CorpUser,
+    ]);
+
+    // Get results from the recommendations or autocomplete
+    const searchResults: Array<Entity> = useMemo(() => {
+        return (
+            autocompleteData?.autoCompleteForMultiple?.suggestions?.flatMap((suggestion) => suggestion.entities) ||
+            recommendedData ||
+            []
+        );
+    }, [autocompleteData?.autoCompleteForMultiple?.suggestions, recommendedData]);
+
+    // Filter search results to only include actors
+    const actorSearchResults = useMemo(() => {
+        return filterActors(searchResults);
+    }, [searchResults]);
+
+    // Sync selectedActorEntities with selectedActorUrns from parent
+    useEffect(() => {
+        const currentSelectedUrns = selectedActorEntities
+            .map((e) => e.urn)
+            .sort()
+            .join(',');
+        const newSelectedUrns = selectedActorUrns.sort().join(',');
+
+        // Only update if the URNs have actually changed
+        if (currentSelectedUrns !== newSelectedUrns) {
+            const entities = resolveActorsFromUrns(selectedActorUrns, {
+                placeholderActors,
+                searchResults,
+                selectedActors: selectedActorEntities,
+            });
+
+            setSelectedActorEntities(entities);
+        }
+    }, [selectedActorUrns, placeholderActors, searchResults, selectedActorEntities]);
+
+    // Use utility to deduplicate entities from all sources
+    // Only include actor entities in the options
+    const allActorEntities = useMemo(() => {
+        const combined = deduplicateEntities({
+            placeholderEntities: placeholderActors,
+            searchResults: actorSearchResults,
+            selectedEntities: selectedActorEntities,
+        });
+        return filterActors(combined);
+    }, [placeholderActors, actorSearchResults, selectedActorEntities]);
+
+    // Convert entities to SelectOption format using utility
+    const selectOptions = entitiesToSelectOptions(allActorEntities, entityRegistry);
+
+    // Handle search
+    const handleSearch = useCallback(
+        (query: string) => {
+            if (query.trim()) {
+                autoCompleteQuery({
+                    variables: {
+                        input: {
+                            types: [EntityType.CorpUser, EntityType.CorpGroup],
+                            query: query.trim(),
+                            limit: 10,
+                        },
+                    },
+                });
+            }
+        },
+        [autoCompleteQuery],
+    );
+
+    // Render actor entity in dropdown
+    const renderDropdownActorLabel = useCallback(
+        (entity: ActorEntity) => {
+            const displayName = entityRegistry.getDisplayName(entity.type, entity);
+            const subtitle = getActorEmail(entity);
+            return (
+                <IconAndNameContainer>
+                    <IconWrapper>
+                        <EntityIcon entity={entity} />
+                    </IconWrapper>
+                    <TitleContainer>
+                        <Text type="div">{displayName}</Text>
+                        {subtitle && (
+                            <Text type="div" size="sm" color="gray">
+                                {subtitle}
+                            </Text>
+                        )}
+                    </TitleContainer>
+                </IconAndNameContainer>
+            );
+        },
+        [entityRegistry],
+    );
+
+    // Render selected actor label
+    const renderSelectedActorLabel = useCallback(
+        (selectedOption: OptionType) => {
+            const entity = allActorEntities.find((e) => e.urn === selectedOption.value);
+            if (!entity) return selectedOption.label;
+
+            const displayName = entityRegistry.getDisplayName(entity.type, entity);
+            const imageUrl = getActorPictureLink(entity);
+
+            return <Avatar name={displayName || ''} imageUrl={imageUrl} showInPill />;
+        },
+        [allActorEntities, entityRegistry],
+    );
+
+    // Handle select change
+    const handleSelectChange = useCallback(
+        (newValues: string[]) => {
+            const newEntities = resolveActorsFromUrns(newValues, {
+                placeholderActors: allActorEntities,
+                selectedActors: selectedActorEntities,
+            });
+
+            setSelectedActorEntities(newEntities);
+            onUpdate(newEntities);
+        },
+        [onUpdate, allActorEntities, selectedActorEntities],
+    );
+
+    // Loading state for the select
+    const isSelectLoading = recommendationsLoading || searchLoading;
+
+    return (
+        <SimpleSelect
+            selectLabelProps={{
+                variant: 'custom',
+            }}
+            options={selectOptions}
+            isLoading={isSelectLoading}
+            values={selectedActorUrns}
+            onUpdate={handleSelectChange}
+            onSearchChange={handleSearch}
+            showSearch={showSearch}
+            isMultiSelect
+            placeholder={placeholder}
+            isDisabled={isDisabled}
+            width={width}
+            renderCustomSelectedValue={renderSelectedActorLabel}
+            renderCustomOptionText={(option) => {
+                const entity = allActorEntities.find((e) => e.urn === option.value);
+                return entity ? renderDropdownActorLabel(entity) : option.label;
+            }}
+        />
+    );
+};

--- a/datahub-web-react/src/app/entityV2/shared/links/DomainColoredIcon.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/links/DomainColoredIcon.tsx
@@ -2,8 +2,8 @@ import * as Muicon from '@mui/icons-material';
 import React from 'react';
 import styled from 'styled-components';
 
-import { REDESIGN_COLORS } from '@app/entityV2/shared/constants';
-import { hexToRgba, useGenerateDomainColorFromPalette } from '@app/sharedV2/colors/colorUtils';
+import { hexToRgb, hexToRgba, useGenerateDomainColorFromPalette } from '@app/sharedV2/colors/colorUtils';
+import { getLighterRGBColor } from '@app/sharedV2/icons/colorUtils';
 
 import { Domain } from '@types';
 
@@ -49,14 +49,18 @@ export const DomainColoredIcon = ({ iconColor, domain, size = 40, fontSize = 20,
 
     const generateColor = useGenerateDomainColorFromPalette();
     const domainColor = domain?.displayProperties?.colorHex || generateColor(domain?.urn || '');
-    const domainBackgroundColor = hexToRgba(iconColor || domainColor, 1.0);
+
+    const domainHexColor = iconColor || domainColor;
+    const [r, g, b] = hexToRgb(domainHexColor);
+    const domainBackgroundColor = `rgb(${getLighterRGBColor(r, g, b).join(', ')})`;
+    const domainIconColor = hexToRgba(domainHexColor, 1.0);
 
     return (
         <DomainIconContainer color={domainBackgroundColor} size={size} onClick={onClick}>
             {MaterialIcon ? (
-                <MaterialIcon style={{ color: `${REDESIGN_COLORS.WHITE}` }} fontSize="large" sx={{ px: 1 }} />
+                <MaterialIcon style={{ color: domainIconColor }} fontSize="large" sx={{ px: 1 }} />
             ) : (
-                <DomainCharacterIcon color={`${REDESIGN_COLORS.WHITE}`} $fontSize={fontSize}>
+                <DomainCharacterIcon color={domainIconColor} $fontSize={fontSize}>
                     {domain?.properties?.name.charAt(0)}
                 </DomainCharacterIcon>
             )}

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/AccessManagement/__tests__/AccessManagement.test.ts
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/AccessManagement/__tests__/AccessManagement.test.ts
@@ -71,7 +71,6 @@ describe('handleAccessRoles (EntityV2)', () => {
                 __typename: 'Dataset',
             },
         };
-
         const externalRole = handleAccessRoles(externalRolesQuery);
         expect(externalRole).toHaveLength(0);
         expect(externalRole).toEqual([]);

--- a/datahub-web-react/src/app/entityV2/shared/utils/__tests__/actorUtils.test.ts
+++ b/datahub-web-react/src/app/entityV2/shared/utils/__tests__/actorUtils.test.ts
@@ -1,0 +1,432 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    ActorEntity,
+    filterActors,
+    findActorByUrn,
+    getActorDisplayName,
+    getActorEmail,
+    getActorPictureLink,
+    hasActorDisplayProperties,
+    isActor,
+    resolveActorsFromUrns,
+} from '@app/entityV2/shared/utils/actorUtils';
+
+import { CorpGroup, CorpUser, Entity, EntityType } from '@types';
+
+// Mock entities for testing
+const mockCorpUser: CorpUser = {
+    urn: 'urn:li:corpuser:user1',
+    type: EntityType.CorpUser,
+    username: 'user1',
+    properties: {
+        displayName: 'John Doe',
+        email: 'john.doe@example.com',
+        fullName: 'John Doe',
+        active: true,
+        firstName: 'John',
+        lastName: 'Doe',
+    },
+    editableProperties: {
+        displayName: 'John Doe (Editable)',
+        pictureLink: 'https://example.com/avatar1.jpg',
+    },
+} as CorpUser;
+
+const mockCorpUser2: CorpUser = {
+    urn: 'urn:li:corpuser:user2',
+    type: EntityType.CorpUser,
+    username: 'user2',
+    properties: {
+        displayName: 'Jane Smith',
+        email: 'jane.smith@example.com',
+        fullName: 'Jane Smith',
+        active: true,
+        firstName: 'Jane',
+        lastName: 'Smith',
+    },
+} as CorpUser;
+
+const mockCorpGroup: CorpGroup = {
+    urn: 'urn:li:corpGroup:group1',
+    type: EntityType.CorpGroup,
+    name: 'engineering',
+    properties: {
+        displayName: 'Engineering Team',
+    },
+    editableProperties: {
+        pictureLink: 'https://example.com/group-avatar.jpg',
+    },
+} as CorpGroup;
+
+// Non-actor entities for negative tests
+const mockDataset = {
+    urn: 'urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)',
+    type: EntityType.Dataset,
+    name: 'SampleHiveDataset',
+    properties: {
+        name: 'Sample Dataset',
+    },
+} as Entity;
+
+const mockDomain = {
+    urn: 'urn:li:domain:engineering',
+    type: EntityType.Domain,
+    properties: {
+        name: 'Engineering Domain',
+    },
+} as Entity;
+
+describe('actorUtils', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('isActor', () => {
+        it('should return true for CorpUser entities', () => {
+            expect(isActor(mockCorpUser)).toBe(true);
+        });
+
+        it('should return true for CorpGroup entities', () => {
+            expect(isActor(mockCorpGroup)).toBe(true);
+        });
+
+        it('should return false for non-actor entities', () => {
+            expect(isActor(mockDataset)).toBe(false);
+            expect(isActor(mockDomain)).toBe(false);
+        });
+
+        it('should return false for null or undefined', () => {
+            expect(isActor(null)).toBe(false);
+            expect(isActor(undefined)).toBe(false);
+        });
+
+        it('should return false for entities without type', () => {
+            const entityWithoutType = { urn: 'test' } as Entity;
+            expect(isActor(entityWithoutType)).toBe(false);
+        });
+    });
+
+    describe('filterActors', () => {
+        it('should filter out only actor entities', () => {
+            const mixedEntities = [mockCorpUser, mockDataset, mockCorpGroup, mockDomain, null, undefined];
+
+            const result = filterActors(mixedEntities);
+
+            expect(result).toHaveLength(2);
+            expect(result[0]).toBe(mockCorpUser);
+            expect(result[1]).toBe(mockCorpGroup);
+        });
+
+        it('should return empty array when no actors present', () => {
+            const nonActorEntities = [mockDataset, mockDomain, null, undefined];
+            const result = filterActors(nonActorEntities);
+            expect(result).toHaveLength(0);
+        });
+
+        it('should handle empty array', () => {
+            const result = filterActors([]);
+            expect(result).toHaveLength(0);
+        });
+
+        it('should preserve all actors when all entities are actors', () => {
+            const actorEntities = [mockCorpUser, mockCorpGroup, mockCorpUser2];
+            const result = filterActors(actorEntities);
+            expect(result).toHaveLength(3);
+            expect(result).toEqual([mockCorpUser, mockCorpGroup, mockCorpUser2]);
+        });
+    });
+
+    describe('findActorByUrn', () => {
+        it('should find actor by URN when it exists and is an actor', () => {
+            const entities = [mockCorpUser, mockDataset, mockCorpGroup];
+
+            const userResult = findActorByUrn(entities, mockCorpUser.urn);
+            const groupResult = findActorByUrn(entities, mockCorpGroup.urn);
+
+            expect(userResult).toBe(mockCorpUser);
+            expect(groupResult).toBe(mockCorpGroup);
+        });
+
+        it('should return undefined when entity exists but is not an actor', () => {
+            const entities = [mockCorpUser, mockDataset];
+            const result = findActorByUrn(entities, mockDataset.urn);
+            expect(result).toBeUndefined();
+        });
+
+        it('should return undefined when URN does not exist', () => {
+            const entities = [mockCorpUser, mockCorpGroup];
+            const result = findActorByUrn(entities, 'urn:li:corpuser:nonexistent');
+            expect(result).toBeUndefined();
+        });
+
+        it('should handle empty entities array', () => {
+            const result = findActorByUrn([], mockCorpUser.urn);
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('resolveActorsFromUrns', () => {
+        it('should resolve actors from multiple sources in priority order', () => {
+            const urns = [
+                mockCorpUser.urn, // Will be found in placeholderActors
+                mockCorpUser2.urn, // Will be found in searchResults
+                mockCorpGroup.urn, // Will be found in selectedActors
+            ];
+
+            const sources = {
+                placeholderActors: [mockCorpUser],
+                searchResults: [mockCorpUser2, mockDataset], // Mixed with non-actor
+                selectedActors: [mockCorpGroup],
+            };
+
+            const result = resolveActorsFromUrns(urns, sources);
+
+            expect(result).toHaveLength(3);
+            expect(result[0]).toBe(mockCorpUser);
+            expect(result[1]).toBe(mockCorpUser2);
+            expect(result[2]).toBe(mockCorpGroup);
+        });
+
+        it('should prefer placeholderActors over other sources', () => {
+            const urns = [mockCorpUser.urn];
+            const differentUser = { ...mockCorpUser, properties: { displayName: 'Different Name' } } as CorpUser;
+
+            const sources = {
+                placeholderActors: [mockCorpUser],
+                searchResults: [differentUser],
+                selectedActors: [differentUser],
+            };
+
+            const result = resolveActorsFromUrns(urns, sources);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]).toBe(mockCorpUser); // From placeholders, not the different one
+        });
+
+        it('should skip non-actor entities in search results', () => {
+            const urns = [mockDataset.urn, mockCorpUser.urn];
+
+            const sources = {
+                searchResults: [mockDataset, mockCorpUser], // Mixed entities
+            };
+
+            const result = resolveActorsFromUrns(urns, sources);
+
+            expect(result).toHaveLength(1); // Only the actor should be resolved
+            expect(result[0]).toBe(mockCorpUser);
+        });
+
+        it('should handle empty URNs array', () => {
+            const result = resolveActorsFromUrns([], {
+                placeholderActors: [mockCorpUser],
+            });
+            expect(result).toHaveLength(0);
+        });
+
+        it('should handle empty sources', () => {
+            const result = resolveActorsFromUrns([mockCorpUser.urn], {});
+            expect(result).toHaveLength(0);
+        });
+
+        it('should handle URNs that cannot be resolved', () => {
+            const urns = ['urn:li:corpuser:unknown', mockCorpUser.urn];
+
+            const sources = {
+                placeholderActors: [mockCorpUser],
+            };
+
+            const result = resolveActorsFromUrns(urns, sources);
+
+            expect(result).toHaveLength(1); // Only the resolvable one
+            expect(result[0]).toBe(mockCorpUser);
+        });
+    });
+
+    describe('hasActorDisplayProperties', () => {
+        it('should return true for valid actor entities', () => {
+            expect(hasActorDisplayProperties(mockCorpUser)).toBe(true);
+            expect(hasActorDisplayProperties(mockCorpGroup)).toBe(true);
+        });
+
+        it('should return false for non-actor entities', () => {
+            expect(hasActorDisplayProperties(mockDataset)).toBe(false);
+            expect(hasActorDisplayProperties(mockDomain)).toBe(false);
+        });
+
+        it('should return false for entities without URN', () => {
+            const entityWithoutUrn = { type: EntityType.CorpUser } as Entity;
+            expect(hasActorDisplayProperties(entityWithoutUrn)).toBe(false);
+        });
+
+        it('should return false for entities without type', () => {
+            const entityWithoutType = { urn: 'test-urn' } as Entity;
+            expect(hasActorDisplayProperties(entityWithoutType)).toBe(false);
+        });
+    });
+
+    describe('getActorDisplayName', () => {
+        it('should get display name from CorpUser properties', () => {
+            expect(getActorDisplayName(mockCorpUser)).toBe('John Doe');
+        });
+
+        it('should fallback to fullName for CorpUser if displayName not available', () => {
+            const userWithoutDisplayName = {
+                ...mockCorpUser,
+                properties: {
+                    ...mockCorpUser.properties,
+                    displayName: undefined,
+                    fullName: 'John Doe Full',
+                },
+            } as CorpUser;
+
+            expect(getActorDisplayName(userWithoutDisplayName)).toBe('John Doe Full');
+        });
+
+        it('should fallback to username for CorpUser if other names not available', () => {
+            const userWithOnlyUsername = {
+                ...mockCorpUser,
+                properties: {
+                    ...mockCorpUser.properties,
+                    displayName: undefined,
+                    fullName: undefined,
+                },
+            } as CorpUser;
+
+            expect(getActorDisplayName(userWithOnlyUsername)).toBe('user1');
+        });
+
+        it('should get display name from CorpGroup properties', () => {
+            expect(getActorDisplayName(mockCorpGroup)).toBe('Engineering Team');
+        });
+
+        it('should fallback to group name if displayName not available', () => {
+            const groupWithoutDisplayName = {
+                ...mockCorpGroup,
+                properties: {
+                    displayName: undefined,
+                },
+            } as CorpGroup;
+
+            expect(getActorDisplayName(groupWithoutDisplayName)).toBe('engineering');
+        });
+
+        it('should return undefined for entities without any name properties', () => {
+            const userWithoutNames = {
+                ...mockCorpUser,
+                username: undefined,
+                properties: {
+                    active: true,
+                },
+            } as unknown as CorpUser;
+
+            expect(getActorDisplayName(userWithoutNames)).toBeUndefined();
+        });
+    });
+
+    describe('getActorEmail', () => {
+        it('should get email from CorpUser properties', () => {
+            expect(getActorEmail(mockCorpUser)).toBe('john.doe@example.com');
+        });
+
+        it('should return undefined for CorpGroup entities', () => {
+            expect(getActorEmail(mockCorpGroup)).toBeUndefined();
+        });
+
+        it('should return undefined for CorpUser without email', () => {
+            const userWithoutEmail = {
+                ...mockCorpUser,
+                properties: {
+                    ...mockCorpUser.properties,
+                    email: undefined,
+                },
+            } as CorpUser;
+
+            expect(getActorEmail(userWithoutEmail)).toBeUndefined();
+        });
+
+        it('should return undefined for CorpUser without properties', () => {
+            const userWithoutProperties = {
+                ...mockCorpUser,
+                properties: undefined,
+            } as CorpUser;
+
+            expect(getActorEmail(userWithoutProperties)).toBeUndefined();
+        });
+    });
+
+    describe('getActorPictureLink', () => {
+        it('should get picture link from editableProperties for both users and groups', () => {
+            expect(getActorPictureLink(mockCorpUser)).toBe('https://example.com/avatar1.jpg');
+            expect(getActorPictureLink(mockCorpGroup)).toBe('https://example.com/group-avatar.jpg');
+        });
+
+        it('should return undefined when editableProperties is missing', () => {
+            const userWithoutEditableProps = {
+                ...mockCorpUser,
+                editableProperties: undefined,
+            } as CorpUser;
+
+            expect(getActorPictureLink(userWithoutEditableProps)).toBeUndefined();
+        });
+
+        it('should return undefined when pictureLink is not set', () => {
+            const userWithoutPicture = {
+                ...mockCorpUser,
+                editableProperties: {
+                    pictureLink: undefined,
+                },
+            } as CorpUser;
+
+            expect(getActorPictureLink(userWithoutPicture)).toBeUndefined();
+        });
+
+        it('should return undefined when editableProperties exists but is empty', () => {
+            const userWithEmptyEditableProps = {
+                ...mockCorpUser,
+                editableProperties: {},
+            } as CorpUser;
+
+            expect(getActorPictureLink(userWithEmptyEditableProps)).toBeUndefined();
+        });
+    });
+
+    // Integration test for typical usage patterns
+    describe('integration scenarios', () => {
+        it('should handle a complete actor resolution workflow', () => {
+            // Simulate a typical component workflow
+            const allUrns = [mockCorpUser.urn, mockCorpUser2.urn, mockCorpGroup.urn, 'urn:li:corpuser:missing'];
+
+            // Mixed entity search results (including non-actors)
+            const searchResults = [mockCorpUser2, mockDataset, mockDomain];
+            const selectedActors = [mockCorpUser];
+            const placeholderActors = [mockCorpGroup];
+
+            // Step 1: Resolve actors from URNs
+            const resolvedActors = resolveActorsFromUrns(allUrns, {
+                placeholderActors,
+                searchResults,
+                selectedActors,
+            });
+
+            expect(resolvedActors).toHaveLength(3); // Missing one is skipped
+
+            // Step 2: Filter mixed results to only actors
+            const filteredSearch = filterActors(searchResults);
+            expect(filteredSearch).toHaveLength(1); // Only mockCorpUser2
+
+            // Step 3: Check display properties
+            resolvedActors.forEach((actor) => {
+                expect(hasActorDisplayProperties(actor)).toBe(true);
+                expect(getActorDisplayName(actor)).toBeDefined();
+            });
+
+            // Step 4: Get specific properties
+            const userActor = resolvedActors.find(isActor) as ActorEntity;
+            if (userActor?.type === EntityType.CorpUser) {
+                const email = getActorEmail(userActor);
+                expect(typeof email === 'string' || email === undefined).toBe(true);
+            }
+        });
+    });
+});

--- a/datahub-web-react/src/app/entityV2/shared/utils/__tests__/selectorUtils.test.ts
+++ b/datahub-web-react/src/app/entityV2/shared/utils/__tests__/selectorUtils.test.ts
@@ -1,0 +1,352 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    buildEntityCache,
+    createOwnerInputs,
+    deduplicateEntities,
+    entitiesToNestedSelectOptions,
+    entitiesToSelectOptions,
+    isEntityResolutionRequired,
+    mergeSelectedIntoOptions,
+    mergeSelectedNestedOptions,
+} from '@app/entityV2/shared/utils/selectorUtils';
+
+import { EntityType, OwnerEntityType, OwnershipType } from '@types';
+
+// Mock entities for testing
+const mockUser1 = {
+    urn: 'urn:li:corpuser:user1',
+    type: EntityType.CorpUser,
+    properties: {
+        displayName: 'User One',
+        email: 'user1@example.com',
+    },
+};
+
+const mockUser2 = {
+    urn: 'urn:li:corpuser:user2',
+    type: EntityType.CorpUser,
+    properties: {
+        displayName: 'User Two',
+        email: 'user2@example.com',
+    },
+};
+
+const mockGroup1 = {
+    urn: 'urn:li:corpGroup:group1',
+    type: EntityType.CorpGroup,
+    properties: {
+        displayName: 'Group One',
+    },
+};
+
+const mockDomain1 = {
+    urn: 'urn:li:domain:engineering',
+    type: EntityType.Domain,
+    properties: {
+        name: 'Engineering',
+        description: 'Engineering domain',
+    },
+    parentDomains: {
+        domains: [{ urn: 'urn:li:domain:parent' }],
+    },
+};
+
+// Mock entity registry
+const mockEntityRegistry = {
+    getDisplayName: vi.fn((type, entity) => {
+        if (type === EntityType.CorpUser) {
+            return entity.properties?.displayName || 'Unknown User';
+        }
+        if (type === EntityType.CorpGroup) {
+            return entity.properties?.displayName || 'Unknown Group';
+        }
+        if (type === EntityType.Domain) {
+            return entity.properties?.name || 'Unknown Domain';
+        }
+        return 'Unknown Entity';
+    }),
+};
+
+describe('selectorUtils', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('buildEntityCache', () => {
+        it('should build a cache map from entities array', () => {
+            const entities = [mockUser1, mockUser2, mockGroup1];
+            const cache = buildEntityCache(entities);
+
+            expect(cache.size).toBe(3);
+            expect(cache.get('urn:li:corpuser:user1')).toBe(mockUser1);
+            expect(cache.get('urn:li:corpuser:user2')).toBe(mockUser2);
+            expect(cache.get('urn:li:corpGroup:group1')).toBe(mockGroup1);
+        });
+
+        it('should handle empty entities array', () => {
+            const cache = buildEntityCache([]);
+            expect(cache.size).toBe(0);
+        });
+
+        it('should handle duplicate URNs by keeping the last one', () => {
+            const duplicateUser = { ...mockUser1, properties: { displayName: 'Updated User' } };
+            const entities = [mockUser1, duplicateUser];
+            const cache = buildEntityCache(entities);
+
+            expect(cache.size).toBe(1);
+            expect(cache.get('urn:li:corpuser:user1')).toBe(duplicateUser);
+        });
+    });
+
+    describe('isEntityResolutionRequired', () => {
+        it('should return true when cache is missing some URNs', () => {
+            const cache = new Map();
+            cache.set('urn:li:corpuser:user1', mockUser1);
+
+            const urns = ['urn:li:corpuser:user1', 'urn:li:corpuser:user2'];
+            const result = isEntityResolutionRequired(urns, cache);
+
+            expect(result).toBe(true);
+        });
+
+        it('should return false when cache has all URNs', () => {
+            const cache = new Map();
+            cache.set('urn:li:corpuser:user1', mockUser1);
+            cache.set('urn:li:corpuser:user2', mockUser2);
+
+            const urns = ['urn:li:corpuser:user1', 'urn:li:corpuser:user2'];
+            const result = isEntityResolutionRequired(urns, cache);
+
+            expect(result).toBe(false);
+        });
+
+        it('should return false for empty URNs array', () => {
+            const cache = new Map();
+            const result = isEntityResolutionRequired([], cache);
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('deduplicateEntities', () => {
+        it('should deduplicate entities from multiple sources', () => {
+            const options = {
+                placeholderEntities: [mockUser1, mockUser2],
+                searchResults: [mockUser2, mockGroup1], // mockUser2 is duplicate
+                selectedEntities: [mockUser1], // mockUser1 is duplicate
+                existingEntityUrns: [],
+            };
+
+            const result = deduplicateEntities(options);
+
+            expect(result).toHaveLength(3);
+            expect(result.map((e) => e.urn)).toEqual([
+                'urn:li:corpuser:user1',
+                'urn:li:corpuser:user2',
+                'urn:li:corpGroup:group1',
+            ]);
+        });
+
+        it('should exclude existing entities but keep selected ones', () => {
+            const options = {
+                placeholderEntities: [mockUser1],
+                searchResults: [mockUser2],
+                selectedEntities: [mockUser1], // This should be included even if it's "existing"
+                existingEntityUrns: ['urn:li:corpuser:user1', 'urn:li:corpuser:user2'],
+            };
+
+            const result = deduplicateEntities(options);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].urn).toBe('urn:li:corpuser:user1'); // Selected entity included
+        });
+
+        it('should handle empty inputs', () => {
+            const result = deduplicateEntities({});
+            expect(result).toHaveLength(0);
+        });
+
+        it('should preserve order (first occurrence wins)', () => {
+            const options = {
+                placeholderEntities: [mockUser1],
+                searchResults: [mockUser2, mockUser1], // mockUser1 appears later
+                selectedEntities: [],
+                existingEntityUrns: [],
+            };
+
+            const result = deduplicateEntities(options);
+
+            expect(result).toHaveLength(2);
+            expect(result[0].urn).toBe('urn:li:corpuser:user1'); // From placeholders (first)
+            expect(result[1].urn).toBe('urn:li:corpuser:user2'); // From search results
+        });
+    });
+
+    describe('entitiesToSelectOptions', () => {
+        it('should convert entities to SelectOption format', () => {
+            const entities = [mockUser1, mockGroup1];
+            const result = entitiesToSelectOptions(entities, mockEntityRegistry as any);
+
+            expect(result).toHaveLength(2);
+            expect(result[0]).toEqual({
+                value: 'urn:li:corpuser:user1',
+                label: 'User One',
+                description: 'user1@example.com',
+            });
+            expect(result[1]).toEqual({
+                value: 'urn:li:corpGroup:group1',
+                label: 'Group One',
+                description: undefined,
+            });
+        });
+
+        it('should handle empty entities array', () => {
+            const result = entitiesToSelectOptions([], mockEntityRegistry as any);
+            expect(result).toHaveLength(0);
+        });
+
+        it('should call entityRegistry.getDisplayName for labels', () => {
+            const entities = [mockUser1];
+            entitiesToSelectOptions(entities, mockEntityRegistry as any);
+
+            expect(mockEntityRegistry.getDisplayName).toHaveBeenCalledWith(EntityType.CorpUser, mockUser1);
+        });
+    });
+
+    describe('entitiesToNestedSelectOptions', () => {
+        it('should convert cached entities to NestedSelectOption format', () => {
+            const cache = new Map();
+            cache.set('urn:li:domain:engineering', mockDomain1);
+
+            const urns = ['urn:li:domain:engineering'];
+            const result = entitiesToNestedSelectOptions(urns, cache, mockEntityRegistry as any);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual({
+                value: 'urn:li:domain:engineering',
+                label: 'Engineering',
+                id: 'urn:li:domain:engineering',
+                parentId: 'urn:li:domain:parent',
+                entity: mockDomain1,
+            });
+        });
+
+        it('should create fallback options for uncached entities', () => {
+            const cache = new Map(); // Empty cache
+            const urns = ['urn:li:domain:engineering'];
+            const result = entitiesToNestedSelectOptions(urns, cache, mockEntityRegistry as any);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual({
+                value: 'urn:li:domain:engineering',
+                label: 'engineering', // Extracted from URN
+                id: 'urn:li:domain:engineering',
+                parentId: undefined,
+                entity: undefined,
+            });
+        });
+
+        it('should handle malformed URNs gracefully', () => {
+            const cache = new Map();
+            const urns = ['invalid-urn'];
+            const result = entitiesToNestedSelectOptions(urns, cache, mockEntityRegistry as any);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].label).toBe('invalid-urn'); // Falls back to full URN
+        });
+    });
+
+    describe('createOwnerInputs', () => {
+        it('should create owner inputs with correct types', () => {
+            const urns = ['urn:li:corpuser:user1', 'urn:li:corpGroup:group1'];
+
+            const result = createOwnerInputs(urns);
+
+            expect(result).toHaveLength(2);
+            expect(result[0]).toEqual({
+                ownerUrn: 'urn:li:corpuser:user1',
+                ownerEntityType: OwnerEntityType.CorpUser,
+                type: OwnershipType.BusinessOwner,
+            });
+            expect(result[1]).toEqual({
+                ownerUrn: 'urn:li:corpGroup:group1',
+                ownerEntityType: OwnerEntityType.CorpGroup,
+                type: OwnershipType.BusinessOwner,
+            });
+        });
+
+        it('should handle empty URNs array', () => {
+            const result = createOwnerInputs([]);
+            expect(result).toHaveLength(0);
+        });
+
+        it('should default to CorpUser for non-group URNs', () => {
+            const urns = ['urn:li:unknown:entity'];
+            const result = createOwnerInputs(urns);
+
+            expect(result[0].ownerEntityType).toBe(OwnerEntityType.CorpUser);
+        });
+    });
+
+    describe('mergeSelectedIntoOptions', () => {
+        it('should merge selected options that are not in current options', () => {
+            const options = [
+                { value: 'option1', label: 'Option 1' },
+                { value: 'option2', label: 'Option 2' },
+            ];
+            const selected = [
+                { value: 'option2', label: 'Option 2' }, // Already in options
+                { value: 'option3', label: 'Option 3' }, // Not in options
+            ];
+
+            const result = mergeSelectedIntoOptions(options, selected);
+
+            expect(result).toHaveLength(3);
+            expect(result.map((o) => o.value)).toEqual(['option1', 'option2', 'option3']);
+        });
+
+        it('should not duplicate options already present', () => {
+            const options = [{ value: 'option1', label: 'Option 1' }];
+            const selected = [
+                { value: 'option1', label: 'Option 1' }, // Already in options
+            ];
+
+            const result = mergeSelectedIntoOptions(options, selected);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].value).toBe('option1');
+        });
+
+        it('should handle empty arrays', () => {
+            expect(mergeSelectedIntoOptions([], [])).toHaveLength(0);
+
+            const options = [{ value: 'option1', label: 'Option 1' }];
+            expect(mergeSelectedIntoOptions(options, [])).toEqual(options);
+            expect(mergeSelectedIntoOptions([], options)).toEqual(options);
+        });
+    });
+
+    describe('mergeSelectedNestedOptions', () => {
+        it('should merge selected nested options', () => {
+            const options = [{ value: 'domain1', label: 'Domain 1', id: 'domain1' }];
+            const selected = [{ value: 'domain2', label: 'Domain 2', id: 'domain2' }];
+
+            const result = mergeSelectedNestedOptions(options, selected);
+
+            expect(result).toHaveLength(2);
+            expect(result.map((o) => o.value)).toEqual(['domain1', 'domain2']);
+        });
+
+        it('should not duplicate nested options', () => {
+            const option = { value: 'domain1', label: 'Domain 1', id: 'domain1' };
+            const options = [option];
+            const selected = [option];
+
+            const result = mergeSelectedNestedOptions(options, selected);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]).toBe(option);
+        });
+    });
+});

--- a/datahub-web-react/src/app/entityV2/shared/utils/actorUtils.ts
+++ b/datahub-web-react/src/app/entityV2/shared/utils/actorUtils.ts
@@ -1,0 +1,99 @@
+import { isCorpGroup } from '@app/entityV2/group/utils';
+import { isCorpUser } from '@app/entityV2/user/utils';
+import { CorpGroup, CorpUser, Entity } from '@src/types.generated';
+
+/**
+ * Type definition for actor entities (CorpUser or CorpGroup)
+ */
+export type ActorEntity = CorpUser | CorpGroup;
+
+/**
+ * Type guard to check if an entity is an actor (CorpUser or CorpGroup)
+ */
+export function isActor(entity?: Entity | null | undefined): entity is ActorEntity {
+    return isCorpUser(entity) || isCorpGroup(entity);
+}
+
+/**
+ * Safely filters entities to only include actors (CorpUser or CorpGroup)
+ * Returns a properly typed array without any hard casts
+ */
+export function filterActors(entities: (Entity | null | undefined)[]): ActorEntity[] {
+    return entities.filter(isActor);
+}
+
+/**
+ * Safely finds an actor entity by URN from a list of entities
+ * Returns properly typed result without hard casts
+ */
+export function findActorByUrn(entities: Entity[], urn: string): ActorEntity | undefined {
+    const entity = entities.find((e) => e.urn === urn);
+    return isActor(entity) ? entity : undefined;
+}
+
+/**
+ * Resolves actor entities from URNs using multiple data sources
+ * Returns properly typed array without hard casts
+ */
+export function resolveActorsFromUrns(
+    urns: string[],
+    sources: {
+        placeholderActors?: ActorEntity[];
+        searchResults?: Entity[];
+        selectedActors?: ActorEntity[];
+    },
+): ActorEntity[] {
+    const { placeholderActors = [], searchResults = [], selectedActors = [] } = sources;
+
+    return urns
+        .map((urn) => {
+            // Try to find in placeholder actors first (already typed)
+            const fromPlaceholders = placeholderActors.find((e) => e.urn === urn);
+            if (fromPlaceholders) return fromPlaceholders;
+
+            // Try to find in search results (need type checking)
+            const fromSearch = findActorByUrn(searchResults, urn);
+            if (fromSearch) return fromSearch;
+
+            // Try to find in selected actors (already typed)
+            const fromSelected = selectedActors.find((e) => e.urn === urn);
+            if (fromSelected) return fromSelected;
+
+            return undefined;
+        })
+        .filter((entity): entity is ActorEntity => entity !== undefined);
+}
+
+/**
+ * Checks if an entity has the properties expected for actor display
+ */
+export function hasActorDisplayProperties(entity: Entity): boolean {
+    return isActor(entity) && Boolean(entity.urn && entity.type);
+}
+
+/**
+ * Type-safe way to get display properties from an actor entity
+ */
+export function getActorDisplayName(entity: ActorEntity): string | undefined {
+    if (isCorpUser(entity)) {
+        return entity.properties?.displayName || entity.properties?.fullName || entity.username;
+    }
+    if (isCorpGroup(entity)) {
+        return entity.properties?.displayName || entity.name;
+    }
+    return undefined;
+}
+
+/**
+ * Type-safe way to get email from an actor (CorpUser only)
+ */
+export function getActorEmail(entity: ActorEntity): string | undefined {
+    return isCorpUser(entity) ? entity.properties?.email || undefined : undefined;
+}
+
+/**
+ * Type-safe way to get picture link from an actor
+ */
+export function getActorPictureLink(entity: ActorEntity): string | undefined {
+    return entity.editableProperties?.pictureLink || undefined;
+}

--- a/datahub-web-react/src/app/entityV2/shared/utils/selectorUtils.ts
+++ b/datahub-web-react/src/app/entityV2/shared/utils/selectorUtils.ts
@@ -1,0 +1,146 @@
+import { NestedSelectOption } from '@src/alchemy-components/components/Select/Nested/types';
+import { SelectOption } from '@src/alchemy-components/components/Select/types';
+import { useEntityRegistryV2 } from '@src/app/useEntityRegistry';
+
+import { Entity, EntityType, OwnerEntityType, OwnershipType } from '@types';
+
+/**
+ * Entity caching utilities
+ */
+export const buildEntityCache = (entities: Entity[]) => {
+    const cache = new Map<string, Entity>();
+    entities.forEach((entity) => cache.set(entity.urn, entity));
+    return cache;
+};
+
+export const isEntityResolutionRequired = (urns: string[], entityCache: Map<string, Entity>) => {
+    const uncachedUrns = urns.filter((urn) => !entityCache.has(urn));
+    return uncachedUrns.length > 0;
+};
+
+/**
+ * Entity deduplication utilities
+ */
+export interface DeduplicateEntitiesOptions {
+    placeholderEntities?: Entity[];
+    searchResults?: Entity[];
+    selectedEntities?: Entity[];
+    existingEntityUrns?: string[];
+}
+
+export const deduplicateEntities = ({
+    placeholderEntities = [],
+    searchResults = [],
+    selectedEntities = [],
+    existingEntityUrns = [],
+}: DeduplicateEntitiesOptions): Entity[] => {
+    // Combine all entity sources
+    const allEntitySources = [...placeholderEntities, ...searchResults, ...selectedEntities];
+
+    // Deduplicate by URN and exclude existing entities
+    // BUT always include selected entities (they must remain in options for removal)
+    const existingUrnsSet = new Set(existingEntityUrns);
+    const selectedUrnsSet = new Set(selectedEntities.map((e) => e.urn));
+    const seenUrns = new Set<string>();
+
+    return allEntitySources.filter((entity) => {
+        // Skip if already seen, unless it's a selected entity that must be included
+        if (seenUrns.has(entity.urn)) {
+            return false;
+        }
+
+        // Skip existing entities (but not selected ones)
+        if (existingUrnsSet.has(entity.urn) && !selectedUrnsSet.has(entity.urn)) {
+            return false;
+        }
+
+        seenUrns.add(entity.urn);
+        return true;
+    });
+};
+
+/**
+ * Convert entities to SelectOption format
+ */
+export const entitiesToSelectOptions = (
+    entities: Entity[],
+    entityRegistry: ReturnType<typeof useEntityRegistryV2>,
+): SelectOption[] => {
+    return entities.map((entity) => ({
+        value: entity.urn,
+        label: entityRegistry.getDisplayName(entity.type, entity),
+        description: entity.type === EntityType.CorpUser ? (entity as any)?.properties?.email : undefined,
+    }));
+};
+
+/**
+ * Convert entities to NestedSelectOption format with fallback labels
+ */
+export const entitiesToNestedSelectOptions = (
+    entityUrns: string[],
+    entityCache: Map<string, Entity>,
+    entityRegistry: ReturnType<typeof useEntityRegistryV2>,
+): NestedSelectOption[] => {
+    return entityUrns.map((urn: string) => {
+        const entity = entityCache.get(urn);
+        if (entity) {
+            return {
+                value: entity.urn,
+                label: entityRegistry.getDisplayName(entity.type, entity),
+                id: entity.urn,
+                parentId: (entity as any).parentDomains?.domains?.[0]?.urn,
+                entity,
+            };
+        }
+
+        // Fallback option when entity isn't hydrated yet
+        // Extract name from URN (e.g., "urn:li:domain:engineering" -> "engineering")
+        const entityName = urn.split(':').pop() || urn;
+        return {
+            value: urn,
+            label: entityName,
+            id: urn,
+            parentId: undefined,
+            entity: undefined,
+        };
+    });
+};
+
+/**
+ * Create owner input objects from URNs
+ */
+export const createOwnerInputs = (selectedOwnerUrns: string[]) => {
+    return selectedOwnerUrns.map((urn) => {
+        // Determine owner type from URN (CorpGroup URNs typically contain 'corpGroup')
+        const ownerEntityType = urn.includes('corpGroup') ? OwnerEntityType.CorpGroup : OwnerEntityType.CorpUser;
+
+        return {
+            ownerUrn: urn,
+            ownerEntityType,
+            type: OwnershipType.BusinessOwner,
+        };
+    });
+};
+
+/**
+ * Merge selected entities into options to ensure they remain visible during search
+ */
+export const mergeSelectedIntoOptions = <T extends { value: string }>(options: T[], selectedOptions: T[]): T[] => {
+    const optionUrns = new Set(options.map((option) => option.value));
+    const selectedNotInOptions = selectedOptions.filter((selected) => !optionUrns.has(selected.value));
+
+    return [...options, ...selectedNotInOptions];
+};
+
+/**
+ * Specialized version for NestedSelectOption merging
+ */
+export const mergeSelectedNestedOptions = (
+    options: NestedSelectOption[],
+    selectedOptions: NestedSelectOption[],
+): NestedSelectOption[] => {
+    const optionUrns = new Set(options.map((option) => option.value));
+    const selectedNotInOptions = selectedOptions.filter((selected) => !optionUrns.has(selected.value));
+
+    return [...options, ...selectedNotInOptions];
+};

--- a/datahub-web-react/src/app/sharedV2/owners/OwnersSection.tsx
+++ b/datahub-web-react/src/app/sharedV2/owners/OwnersSection.tsx
@@ -70,6 +70,7 @@ interface Props<T> {
     onChange: (owners: T[]) => void;
     sourceRefetch?: () => Promise<any>;
     isEditForm?: boolean;
+    canEdit?: boolean;
     shouldSetOwnerEntities?: boolean;
 }
 
@@ -83,6 +84,7 @@ const OwnersSection = <T,>({
     onChange,
     sourceRefetch,
     isEditForm = false,
+    canEdit = true,
     shouldSetOwnerEntities = false,
 }: Props<T>) => {
     const entityRegistry = useEntityRegistry();
@@ -213,6 +215,7 @@ const OwnersSection = <T,>({
                     loading={isSelectLoading}
                     notFoundContent={notFoundContent}
                     optionLabelProp="label"
+                    disabled={!canEdit}
                 >
                     {finalResults.map((entity) => renderSearchResult(entity))}
                 </SelectInput>
@@ -226,6 +229,7 @@ const OwnersSection = <T,>({
                                 entityUrn={owner.associatedUrn}
                                 owner={owner}
                                 refetch={sourceRefetch}
+                                readOnly={!canEdit}
                             />
                         ))
                     ) : (

--- a/datahub-web-react/src/graphql/me.graphql
+++ b/datahub-web-react/src/graphql/me.graphql
@@ -1,6 +1,7 @@
 query getMe {
     me {
         corpUser {
+            type
             urn
             username
             info {

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -497,6 +497,7 @@ module.exports = {
     },
     {
       "DataHub Cloud Release History": [
+        "docs/managed-datahub/release-notes/v_0_3_15",
         "docs/managed-datahub/release-notes/v_0_3_14",
         "docs/managed-datahub/release-notes/v_0_3_13",
         "docs/managed-datahub/release-notes/v_0_3_12",

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -249,6 +249,11 @@ module.exports = {
           id: "docs/domains",
         },
         {
+          label: "File Upload and Download in Documentation",
+          type: "doc",
+          id: "docs/features/feature-guides/file-upload-download",
+        },
+        {
           label: "Incidents",
           type: "doc",
           id: "docs/incidents/incidents",

--- a/docs/authorization/policies.md
+++ b/docs/authorization/policies.md
@@ -207,19 +207,19 @@ These privileges are to view & modify any entity within DataHub.
 
 #### Entity Privileges
 
-| Entity Privileges                  | Description                                                                                |
-| ---------------------------------- | ------------------------------------------------------------------------------------------ |
-| View Entity Page                   | Allow actor to view the entity page.                                                       |
-| Edit Entity                        | Allow actor to edit any information about an entity. Super user privileges for the entity. |
-| Delete                             | Allow actor to delete this entity.                                                         |
-| Create Entity                      | Allow actor to create an entity if it doesn't exist.                                       |
-| Entity Exists                      | Allow actor to determine whether the entity exists.                                        |
-| Execute Entity                     | Allow actor to execute entity ingestion.                                                   |
-| Get Timeline API[^3]               | Allow actor to use the GET Timeline API.                                                   |
-| Get Entity + Relationships API[^3] | Allow actor to use the GET Entity and Relationships API.                                   |
-| Get Aspect/Entity Count APIs[^3]   | Allow actor to use the GET Aspect/Entity Count APIs.                                       |
-| View Entity[^1]                    | Allow actor to view the entity in search results.                                          |
-| Share Entity[^1]                   | Allow actor to share an entity with another DataHub Cloud instance.                        |
+| Entity Privileges                  | Description                                                                                                                                          |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| View Entity Page                   | Allow actor to view the entity page.                                                                                                                 |
+| Edit Entity                        | Allow actor to edit any information about an entity. Super user privileges for the entity.                                                           |
+| Delete                             | Allow actor to delete this entity.                                                                                                                   |
+| Create Entity                      | Allow actor to create an entity if it doesn't exist.                                                                                                 |
+| Entity Exists                      | Allow actor to determine whether the entity exists.                                                                                                  |
+| Execute Entity                     | Allow actor to execute entity ingestion.                                                                                                             |
+| Get Timeline API[^3]               | Allow actor to use the GET Timeline API.                                                                                                             |
+| Get Entity + Relationships API[^3] | Allow actor to use the GET Entity and Relationships API.                                                                                             |
+| Get Aspect/Entity Count APIs[^3]   | Allow actor to use the GET Aspect/Entity Count APIs.                                                                                                 |
+| View Entity[^1]                    | Allow actor to view the entity in search results. This privilege can be explicitly granted, but is also implied by the `View Entity Page` privilege. |
+| Share Entity[^1]                   | Allow actor to share an entity with another DataHub Cloud instance.                                                                                  |
 
 #### Aspect Privileges
 

--- a/docs/features/feature-guides/file-upload-download.md
+++ b/docs/features/feature-guides/file-upload-download.md
@@ -1,0 +1,202 @@
+---
+title: File Upload and Download in Documentation
+---
+
+import FeatureAvailability from '@site/src/components/FeatureAvailability';
+
+# File Upload and Download in Documentation
+
+<FeatureAvailability />
+
+DataHub's File Upload and Download capability enables you to enrich your asset and column documentation with supporting files like images, diagrams, and other resources, making your data catalog more informative and easier to understand.
+
+<p align="center">
+  <img
+       width="70%"  
+       src="https://raw.githubusercontent.com/datahub-project/static-assets/refs/heads/main/imgs/file_upload_download/drop_file_upload.png"
+       alt="Dropping a file to upload"/>
+</p>
+
+## Why Use File Uploads in Documentation?
+
+File uploads transform how you document and communicate about your data assets by enabling you to:
+
+- **Enhance Documentation Quality**: Add visual diagrams, architecture drawings, and screenshots directly into your documentation to illustrate complex concepts
+- **Centralize Resources**: Keep all relevant documentation materials in one place alongside your data assets rather than scattered across multiple systems
+- **Improve Understanding**: Help users grasp data structures, pipelines, and relationships faster with visual aids embedded directly in context
+- **Standardize Communication**: Create consistent, professional documentation that combines text and visual elements
+
+Whether you're a data engineer documenting a complex data pipeline, a data analyst explaining column definitions with example screenshots, or a data steward providing reference materials, file uploads make your documentation more comprehensive and accessible.
+
+## What's Included
+
+### Supported File Types
+
+Currently, images are displayed inline within your documentation. Files of other types can be uploaded and downloaded, with support for additional inline previews (like PDFs and text files) coming in future releases.
+
+### Upload Methods
+
+You have two convenient ways to add files to your documentation:
+
+- **Drag and Drop**: Simply drag files from your file system directly into the documentation editor
+- **Upload Button**: Click the upload file button in the editor toolbar to browse and select files from your file system
+
+<p align="center">
+  <img
+       width="70%"  
+       src="https://raw.githubusercontent.com/datahub-project/static-assets/refs/heads/main/imgs/file_upload_download/upload_file_button.png"
+       alt="Option to choose a file from your system"/>
+</p>
+
+### File Management
+
+When you upload a file, DataHub automatically:
+
+- Creates a new `dataHubFile` entity to track metadata about your file (type, size, original filename)
+- Stores the context of where you uploaded the file (asset documentation, column documentation, etc.)
+- Uses this context information to enforce permissions when users attempt to download files
+
+Files are securely stored in S3, and access is controlled based on the user's permissions for the asset where the file was uploaded.
+
+## Setting Up File Uploads
+
+File upload functionality requires configuration to connect DataHub to your S3 storage.
+
+### Prerequisites
+
+Your DataHub instance must be deployed on AWS for the AWS role authentication to work seamlessly.
+
+### Required Configuration
+
+Set the following environment variables in your DataHub GMS service:
+
+#### DATAHUB_BUCKET_NAME
+
+The name of your S3 bucket where uploaded files will be stored.
+
+```bash
+DATAHUB_BUCKET_NAME=your-datahub-files-bucket
+```
+
+#### DATAHUB_ROLE_ARN
+
+The AWS role ARN configured with permissions to upload and download files from your S3 bucket.
+
+```bash
+DATAHUB_ROLE_ARN=arn:aws:iam::123456789012:role/DataHubFileAccessRole
+```
+
+### AWS Role Configuration
+
+Your AWS role must be properly configured with two key requirements:
+
+#### S3 Permissions
+
+The role needs appropriate permissions to interact with your S3 bucket. At minimum, this should include:
+
+- `s3:PutObject` - To upload files
+- `s3:GetObject` - To download files
+- `s3:DeleteObject` - For garbage collection of unused files
+
+Configure these permissions through an IAM policy attached to the role.
+
+#### Trust Relationship
+
+Update the trust relationship for your role to allow your DataHub GMS service to assume it. The trust policy should permit the AWS service or role that your DataHub GMS is running under to assume this role.
+
+Without proper trust relationship configuration, DataHub will not be able to authenticate with AWS to access your S3 bucket.
+
+## Uploading Files
+
+To add files to your documentation:
+
+1. Navigate to the asset or column where you want to add documentation
+2. Open the documentation editor
+3. Either:
+   - Drag and drop your file directly into the editor, or
+   - Click the upload file button in the toolbar and select your file from the file system dialog
+4. Images will appear inline immediately; other file types will show as downloadable links
+5. Save your documentation changes
+
+Files are uploaded to S3 as soon as you add them to the editor, even before you save your documentation changes.
+
+<p align="center">
+  <img
+       width="70%"  
+       src="https://raw.githubusercontent.com/datahub-project/static-assets/refs/heads/main/imgs/file_upload_download/image_file_example.png"
+       alt="Image file rendered inline"/>
+</p>
+
+## Downloading Files
+
+When users view documentation containing uploaded files:
+
+- **Images**: Display inline automatically within the documentation
+- **Other Files**: Appear as download links that users can click to retrieve the file
+
+### Permission Checks
+
+When a user attempts to download a file, DataHub verifies that they have permission to view the asset or column where the file was originally uploaded. This ensures that file access respects your existing DataHub permission structure.
+
+If a user doesn't have permission to view the associated asset, they won't be able to download the file, even if they have a direct link to it.
+
+## File Metadata and Tracking
+
+Each uploaded file is represented as a `dataHubFile` entity in DataHub, which stores:
+
+- **File type**: The MIME type of the uploaded file
+- **File size**: Size in bytes
+- **Original filename**: The name of the file when it was uploaded
+- **Upload context**: The entity (asset or column) where the file was added
+
+This metadata enables future features like file search, usage tracking, and cleanup of orphaned files.
+
+## Best Practices
+
+When using file uploads in your documentation:
+
+- **Use descriptive filenames**: Original filenames are preserved, making it easier to identify files later
+- **Optimize image sizes**: Large images may take longer to load; consider resizing before upload
+- **Provide context**: Add text descriptions around images to explain what users are seeing
+- **Consider alternatives for large files**: For very large files, consider linking to external storage rather than uploading directly
+- **Review permissions**: Ensure your S3 role and bucket permissions are configured correctly before enabling this feature for users
+
+## Troubleshooting
+
+### Files Not Uploading
+
+If files fail to upload, check:
+
+- Your `DATAHUB_BUCKET_NAME` is set correctly and the bucket exists
+- Your `DATAHUB_ROLE_ARN` is valid and points to an existing role
+- The trust relationship on your AWS role permits your DataHub GMS to assume it
+- The role has necessary S3 permissions (`s3:PutObject`)
+- Ensure that your S3 bucket has a CORS policy set to accept uploads from your host URL
+
+### Files Not Downloading
+
+If users cannot download files, verify:
+
+- Users have permission to view the asset where the file was uploaded
+- Your AWS role has `s3:GetObject` permissions on the bucket
+- The file still exists in S3 (hasn't been manually deleted)
+
+### Authentication Issues
+
+If you see AWS authentication errors:
+
+- Confirm your DataHub instance is deployed on AWS
+- Verify the trust relationship configuration on your AWS role
+- Check that your GMS service has the necessary AWS credentials or instance profile
+
+## Next Steps
+
+Now that you understand how to use file uploads in documentation:
+
+- **Configure your environment**: Set up the required S3 bucket and AWS role
+- **Test with images**: Start by uploading images to asset documentation to see how inline display works
+- **Train your team**: Show data owners and stewards how to enrich their documentation with visual aids
+- **Monitor usage**: Keep an eye on your S3 bucket to understand storage needs
+- **Stay tuned**: Watch for upcoming features like PDF previews and additional file type support
+
+File uploads are designed to make your DataHub documentation more comprehensive and user-friendly, helping your organization build a richer, more informative data catalog.

--- a/docs/features/feature-guides/logical-models/overview.md
+++ b/docs/features/feature-guides/logical-models/overview.md
@@ -38,6 +38,66 @@ Columns on the logical parent and physical children can be linked as well:
 
 ## Creating Logical Models
 
+Logical models are created like any DataHub dataset. We recommend using the Python SDK.
+
+:::note Logical Model Platform
+All DataHub datasets require a platform, representing where the dataset exists. If your logical models are stored in a system users are familiar with, we recommend creating a custom platform for that system and providing a custom icon. Otherwise, we recommend using the platform `logical`, which has a special default icon.
+:::
+
+### Create Dataset in "logical" Platform
+
+```python
+    from datahub.sdk import DataHubClient, Dataset
+    client = DataHubClient.from_env()
+    dataset = Dataset(
+        platform="logical",
+        name=logical_model_name,
+        description=logical_model_description,
+        schema=[
+            # tuples of (field name / field path, data type, description)
+            (
+                "zipcode",
+                "varchar(50)",
+                "This is the zipcode of the address. Specified using extended form and limited to addresses in the United States",
+            ),
+            ("street", "varchar(100)", "Street corresponding to the address"),
+            ("date_column", "date", "Date of the last sale date for this property"),
+        ],
+    )
+    client.entities.upsert(dataset)
+```
+
+### Create Dataset in Custom Platform
+
+```python
+    # Create custom platform with custom logo
+    from datahub.sdk import DataHubClient
+    from datahub.emitter.mcp import MetadataChangeProposalWrapper
+    from datahub.metadata.schema_classes import DataPlatformInfoClass, PlatformTypeClass
+    from datahub.metadata.urns import DataPlatformUrn
+
+    urn = DataPlatformUrn("<platformName>").urn()
+    aspect = DataPlatformInfoClass(
+        name="<platformName>",
+        type=PlatformTypeClass.OTHERS,
+        datasetNameDelimiter=".",
+        logoUrl="<url>"
+    )
+    client = DataHubClient.from_env()
+    client._graph.emit(MetadataChangeProposalWrapper(entityUrn=urn, aspect=aspect))
+
+    # Create dataset in custom platform
+    from datahub.sdk import DataHubClient, Dataset
+    client = DataHubClient.from_env()
+    dataset = Dataset(
+        platform="<platformName>",
+        ...  # See above
+    )
+    client.entities.upsert(dataset)
+```
+
+## Linking Logical Models
+
 At its core, the logical -> physical relationship is created by the [`LogicalParent`](../../../generated/metamodel/entities/dataset.md#logicalparent) aspect. To link columns, this aspect must also be created on each child schmea field entity. However, for ease of use, we recommend the OpenAPI endpoint.
 
 ### OpenAPI
@@ -45,7 +105,7 @@ At its core, the logical -> physical relationship is created by the [`LogicalPar
 The OpenAPI endpoint creates a logical -> physical relationship for a single logical-physical pair, as well as the column-level relationships between their columns, if specified.
 
 ```shell
-curl -X POST 'http://localhost:8080/openapi/v3/entity/logical/<physical_child_urn>/relationship/physicalInstanceOf/<logical_model_urn>' \
+curl -X POST 'http://localhost:8080/openapi/v3/logical/<physical_child_urn>/relationship/physicalInstanceOf/<logical_model_urn>' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -55,6 +115,14 @@ curl -X POST 'http://localhost:8080/openapi/v3/entity/logical/<physical_child_ur
   }'
 ```
 
+These relationships can also be removed (as of DataHub Cloud v0.3.15):
+
+```shell
+curl -X DELETE 'http://localhost:8080/openapi/v3/logical/<physical_child_urn>/relationship/physicalInstanceOf' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json'
+```
+
 ### Python SDK
 
 The Python SDK can also query the same endpoint:
@@ -62,7 +130,7 @@ The Python SDK can also query the same endpoint:
 ```python
     from datahub.sdk import DataHubClient
     client = DataHubClient.from_env()
-    url = f"{client._graph.config.server}/openapi/v3/entity/logical/{child_urn}/relationship/physicalInstanceOf/{parent_urn}"
+    url = f"{client._graph.config.server}/openapi/v3/logical/{child_urn}/relationship/physicalInstanceOf/{parent_urn}"
     client._graph._post_generic(url, {column.parent_name: column.child_name for column in columns})
 ```
 

--- a/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
+++ b/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
@@ -145,7 +145,7 @@ To update your Remote Executor deployment (e.g., to deploy a new container versi
 2. **Update Template**
    - Select **Replace current template**
    - Choose **Upload a template file**
-   - Download the latest DataHub Cloud Remote Executor [CloudFormation Template](https://raw.githubusercontent.com/acryldata/datahub-cloudformation/master/Ingestion/templates/python.ecs.template.yaml)
+   - Download the latest DataHub Cloud Remote Executor [CloudFormation Template](https://raw.githubusercontent.com/acryldata/datahub-cloudformation/master/remote-executor/datahub-executor.ecs.template.yaml)
    - Upload the template file
 
 <p align="center">

--- a/docs/managed-datahub/release-notes/v_0_3_15.md
+++ b/docs/managed-datahub/release-notes/v_0_3_15.md
@@ -1,0 +1,61 @@
+# v0.3.15
+
+:::info
+
+This contains detailed release notes, but there's also an [announcement blog post](https://datahub.com/blog/datahub-cloud-v0-3-15/) that covers the highlights.
+
+:::
+
+#### Release Availability Date
+
+31-Oct-2025
+
+#### Recommended Versions
+
+- **CLI/SDK**: 1.3.1
+- **Remote Executor**: v0.3.15-acryl (recommended), v0.3.14-acryl, v0.3.13.2-acryl, v0.3.13.1-acryl, v0.3.13-acryl, v0.3.12.4-acryl
+- **On-Prem Versions**:
+  - **Helm**: 1.5.140
+  - **API Gateway**: 0.5.4
+  - **Actions**: 0.0.3
+
+## Release Changelog
+
+### v0.3.15-acryl
+
+New Features:
+
+- **Asset Docs File Upload**: You can now upload files directly to asset and schema field documentation! This feature, currently in private beta, supports images, PDFs, CSVs, and more, allowing you to consolidate all your information in one place — in DataHub!
+- **Platforms Home Page Module**: A new Platforms module is now available for your homepage, allowing you to highlight the different platforms represented in your DataHub instance.
+- **Structured Property Settings**: You can now hide structured properties from your asset sidebar when no value is set. This lets you highlight important properties while minimizing noise by hiding unset ones.
+- Moved logical models OpenAPI APIs to their own controller at `/v3/logical/` and added bulk DELETE endpoint
+- **Bulk Un-Mark Anomalies**: Unmark several anomalies in one go via the 'Tune predictions' modal
+- **SQL expressions for Column validity assertions**: Validate columns against reference tables with SQL expressions.
+- **SQL Anomaly Detection**: Detect anomalies on the return value of your SQL assertions. This feature requires seven days of training data and cannot be bootstrapped from historical results.
+- **Bulk Subscription Management**: Manage all of your and your groups' subscriptions in the new subscription dashboard. You can search and filter through your subscriptions, and bulk edit or delete them.
+- **New Search Filter: Asset-Level Lineage**: Quickly narrow down large sets of Search results sets to identify well-connected assets with established lineage dependencies.
+- **Custom AI Documentation Instructions**: Configure custom base prompts used to guide our AI model when generating documentation for Tables and Columns. Useful to enforce standards, guidelines, best practices.
+- **Custom Ask DataHub Instructions**: Configure custom base prompts used to guide our AI assistant when generating answers to user questions. Useful for providing organization-wide context that can be used to inform AI responses in Slack + Teams.
+- **Ask DataHub in DataHub** (Private Beta): Have conversations with DataHub AI directly inside DataHub's interface in a new Chat experience. Reach out to your customer support representative for more information.
+- **IAM Authentication Support**: MySQL and PostgreSQL sources now support IAM authentication.
+- **Unity Catalog/Databricks**: Use SQL to extract query history for usage instead of API calls.
+- **Fivetran Google Sheets Support**: Added Google Sheets connector support with Fivetran API client integration.
+
+Fixes:
+
+- **Quality Tab Performance**: Page performance when loading hundreds of assertions is significantly improved with this release
+- **Hierarchy Module Auth Fix**: Previously, if a user was not able to view a Domain in a hierarchy module, we would not show anything. Now we always return the Domains in this module that a user is authorized to see as expected.
+- **Domains & Glossary Names Truncation**: Previously, if someone opened up the asset sidebar and that caused the name of a Domain or Glossary entity, we would show the truncated name with "..." and if they closed the sidebar the name would remain truncated. This odd UI bug should now be resolved.
+- **Ask DataHub Settings Refresh**: Previously, restart of integrations service pod was required for enable/disable change for Ask DataHub (@DataHub) settings to take effect. Now, the settings are auto-refreshed every 5 minutes.
+- **Invite Users**: Fixes for better discoverability of the feature.
+- **Comprehensive Ingestion Log Export**: Resolves issue where Ingestion Log downloads were truncated due to large file size; available for all ingestion runs, including those using DataHub Remote Executor.
+- **Empty Column Names**: Fixed handling of empty column names from Snowflake access history that were causing ingestion failures.
+- **SQLAlchemy Compatibility**: Fixed compatibility issues with SQLAlchemy 1.4+ versions.
+- **Pydantic v2 upgrade in SDK**: Removed support for Pydantic v1, migrated to Pydantic v2.
+- **Bug fixes and performance fixes in ~11 connectors**: Snowflake, Dremio, MSSQL, MongoDB, Delta Lake, Teradata, Redshift, Metabase, Grafana, CockroachDB, MariaDB, etc.
+
+## Known Issues
+
+- **executor-coordinator backwards compatibility:** TODO: @Anton @Sergio please describe
+- PATCH of the Ownership aspect does not support assigning the same owner to multiple ownership type urns
+- If you were to upgrade to v0.3.15 and create a "Platforms" home page module, in order to roll back to a previous version of DataHub you will need to either (1) remove the Platforms modules from all home page templates or (2) roll back to v0.3.14.2 which includes a fix to handle unknown module types. This sort of backwards compatibility with home page modules is resolved going forward with v0.3.15.

--- a/docs/managed-datahub/subscription-and-notification.md
+++ b/docs/managed-datahub/subscription-and-notification.md
@@ -46,7 +46,7 @@ If you want to create and manage group-level Subscriptions for your team, you wi
 
 The first step to getting notified is identifying the assets you want to subscribe to.
 DataHub’s [Lineage and Impact Analysis features](../../docs/act-on-metadata/impact-analysis.md#lineage-impact-analysis-setup-prerequisites-and-permissions) can help you identify upstream entities that could impact the assets you use and are responsible for.
-You can use the Subscriptions && Notifications feature to sign up for updates for your entire team, or just for yourself.
+You can use the Subscriptions & Notifications feature to sign up for updates for your entire team, or just for yourself.
 
 ### Individually Subscribing to an Entity
 
@@ -72,13 +72,13 @@ You can find your Slack Member ID in your profile settings.
 
 ### Subscribing Your Team/Group to Notifications
 
-The dropdown menu next to the Subscribe button lets you choose who the subscription is for. To create a group subscription, click on Manage Group Subscriptions.
+The dropdown menu next to the Subscribe button lets you choose who the subscription is for. To create a group subscription, click on **Manage for Groups**.
 
 <p align="center">
   <img width="70%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-subscription-dropdown.png"/>
 </p>
 
-Next, customize the group’s subscriptions by selecting the types of changes you want the group to be notified about.
+Next, customize the group's subscription by selecting the types of changes you want the group to be notified about.
 
 <p align="center">
   <img width="70%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-group-subscription-settings.png"/>
@@ -96,10 +96,6 @@ Connect to Slack. Currently, DataHub Cloud's Subscriptions and Notifications fea
 You can enable, disable, or manage notifications at any time to ensure that you receive relevant updates.
 
 Simply use the Dropdown menu next to the Subscribe button to unsubscribe from the asset, or to manage/modify your subscription (say, to modify the changes you want to be updated about).
-
-<p align="center">
-  <img width="70%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-subscription-dropdown.png"/>
-</p>
 
 You can also view and manage your subscriptions in your DataHub settings page.
 

--- a/metadata-ingestion-modules/airflow-plugin/tox.ini
+++ b/metadata-ingestion-modules/airflow-plugin/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39-airflow27, py310-airflow27, py310-airflow28, py311-airflow29, py311-airflow210
+envlist = py310-airflow27, py310-airflow28, py311-airflow29, py311-airflow210
 
 [testenv]
 use_develop = true
@@ -24,7 +24,6 @@ deps =
     airflow210: apache-airflow~=2.10.0
 
     # Respect the Airflow constraints files.
-    py39-airflow27: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.9.txt
     py310-airflow27: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.10.txt
     py310-airflow28: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.8.1/constraints-3.10.txt
     py311-airflow29: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
@@ -336,24 +336,18 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                             except (json.JSONDecodeError, TypeError) as e:
                                 logger.debug(f"Failed to parse outputs JSON: {e}")
 
-                        if "parameters" in signature_raw:
+                        if "params" in signature_raw:
                             try:
-                                signature_data["parameters"] = json.loads(
-                                    signature_raw["parameters"]
+                                signature_data["params"] = json.loads(
+                                    signature_raw["params"]
                                 )
                             except (json.JSONDecodeError, TypeError) as e:
-                                logger.debug(f"Failed to parse parameters JSON: {e}")
+                                logger.debug(f"Failed to parse params JSON: {e}")
 
                         return ModelSignature(
-                            inputs=signature_data["inputs"]
-                            if "inputs" in signature_raw
-                            else None,
-                            outputs=signature_data["outputs"]
-                            if "outputs" in signature_raw
-                            else None,
-                            parameters=signature_data["parameters"]
-                            if "parameters" in signature_raw
-                            else None,
+                            inputs=signature_data.get("inputs"),
+                            outputs=signature_data.get("outputs"),
+                            parameters=signature_data.get("params"),
                         )
                     else:
                         logger.debug(

--- a/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
+++ b/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
@@ -133,6 +133,7 @@ model_uuid: abc123
 signature:
   inputs: '[{"name": "feature1", "type": "double"}, {"name": "feature2", "type": "double"}, {"name": "feature3", "type": "long"}]'
   outputs: '[{"name": "prediction", "type": "long"}]'
+  params: '[{"name": "temperature", "type": "float", "default": 0.7}]'
 """
 
     mock_download_response = mock.MagicMock()

--- a/metadata-ingestion/tests/integration/unity/unity_catalog_ml_model_mces_golden.json
+++ b/metadata-ingestion/tests/integration/unity/unity_catalog_ml_model_mces_golden.json
@@ -2255,6 +2255,7 @@
             "customProperties": {
                 "signature.inputs": "[{\"name\": \"feature1\", \"type\": \"double\"}, {\"name\": \"feature2\", \"type\": \"double\"}, {\"name\": \"feature3\", \"type\": \"long\"}]",
                 "signature.outputs": "[{\"name\": \"prediction\", \"type\": \"long\"}]",
+                "signature.parameters": "[{\"name\": \"temperature\", \"type\": \"float\", \"default\": 0.7}]",
                 "mlflow.user": "\"abc@acryl.io\"",
                 "mlflow.source.type": "\"NOTEBOOK\"",
                 "model_type": "\"classifier\""

--- a/metadata-ingestion/tests/unit/test_unity_catalog_proxy.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_proxy.py
@@ -1538,7 +1538,7 @@ mlflow_version: 2.0.1
 signature:
   inputs: '[{"name": "text", "type": "string"}]'
   outputs: '[{"name": "label", "type": "string"}]'
-  parameters: '[{"name": "temperature", "type": "float", "default": 0.7}]'
+  params: '[{"name": "temperature", "type": "float", "default": 0.7}]'
 """
 
         mock_download_response = MagicMock()


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables setting owners when creating Domains (backend + schema + tests), adds new Domain selector and Owners UI with nested select improvements, updates docs (file uploads, logical models, release notes), refreshes Airflow plugin CI/tox matrices, and parses MLflow model signature params from Unity.
> 
> - **Backend (GraphQL Domain)**:
>   - Allow passing `owners` in `CreateDomainInput`; validate and add owners during domain creation in `CreateDomainResolver`.
>   - Enhance `OwnerUtils` to resolve `ownershipTypeUrn` (default from type) and validate inputs.
>   - Update schema: `CreateDomainInput` includes optional `owners`.
>   - Expand tests to cover owners and parent/no-parent cases.
> - **Web UI**:
>   - New `DomainSelector` with infinite scroll + search; integrated into `CreateDomainModal`.
>   - New lightweight `OwnersSection` using `ActorsSearchSelect`; hook up to domain creation.
>   - Improve Nested Select: default `isMultiSelect=true`, add single-select behavior; extend tests.
>   - Tweak domain icon colors (`DomainColoredIcon`).
> - **Ingestion (Unity/Databricks)**:
>   - Parse MLflow model signature `params` and map to `parameters`; update tests and golden files.
> - **CI/Build**:
>   - Airflow plugin matrix/tox: drop py3.9, add Airflow 2.10.x entries; align constraints.
> - **Docs**:
>   - Add “File Upload and Download in Documentation” guide + sidebar.
>   - Update Logical Models guide (new `/v3/logical` endpoints and delete), Remote Executor CFN link, policies clarifications, subscriptions copy.
>   - Add Cloud release notes v0.3.15 and sidebar entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9bd4d001fa4b98e944b4a064f4d1c6ad667741f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->