### PR TITLE
fix(ci): bundle constraints.txt in acryl-datahub PyPI wheel

### DIFF
--- a/.github/workflows/publish-pypi-release.yml
+++ b/.github/workflows/publish-pypi-release.yml
@@ -51,4 +51,5 @@ jobs:
           RELEASE_SKIP_TEST: "true"
         run: |
           cd metadata-ingestion
+          cp constraints.txt src/datahub/constraints.txt
           RELEASE_VERSION=${{ needs.setup.outputs.tag }} ./scripts/release.sh

--- a/.github/workflows/publish-pypi-release.yml
+++ b/.github/workflows/publish-pypi-release.yml
@@ -20,9 +20,8 @@ jobs:
         id: tag
         run: |
           echo "GITHUB_REF: $GITHUB_REF"
-          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
-          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/tags/v,,g')
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          TAG="${GITHUB_REF#refs/tags/v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
   push_to_pypi:
     name: Build and push python package to PyPI
     runs-on: ubuntu-latest


### PR DESCRIPTION
The publish-pypi-release.yml workflow calls release.sh directly, skipping the gradle buildWheel task that copies constraints.txt into src/datahub/. Wheels on PyPI shipped without it, breaking acryl-executor's constraint feature.

Add the cp before release.sh so setup.py's package_data bundles the file.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
