### PR TITLE
fix(ingestion): Explicitly set Snowflake authentication_type in recipe

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/__tests__/snowflake.test.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/__tests__/snowflake.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    SNOWFLAKE_AUTHENTICATION_TYPE,
+    SNOWFLAKE_PRIVATE_KEY,
+    SNOWFLAKE_PRIVATE_KEY_PASSWORD,
+} from '@app/ingest/source/builder/RecipeForm/snowflake';
+
+describe('Snowflake (legacy ingest) authentication type helpers', () => {
+    describe('setSnowflakeAuthTypeOnRecipe', () => {
+        it('writes KEY_PAIR_AUTHENTICATOR into the recipe when Private Key is selected', () => {
+            const recipe = { source: { config: { account_id: 'xyz123' } } };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.setValueOnRecipeOverride?.(recipe, 'KEY_PAIR_AUTHENTICATOR');
+
+            expect(result.source.config.authentication_type).toBe('KEY_PAIR_AUTHENTICATOR');
+        });
+
+        it('writes DEFAULT_AUTHENTICATOR into the recipe when Username & Password is selected', () => {
+            const recipe = { source: { config: { account_id: 'xyz123' } } };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.setValueOnRecipeOverride?.(recipe, 'DEFAULT_AUTHENTICATOR');
+
+            expect(result.source.config.authentication_type).toBe('DEFAULT_AUTHENTICATOR');
+        });
+
+        it('drops password credentials when switching to key pair authentication', () => {
+            const recipe = { source: { config: { password: 'secret' } } };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.setValueOnRecipeOverride?.(recipe, 'KEY_PAIR_AUTHENTICATOR');
+
+            expect(result.source.config.authentication_type).toBe('KEY_PAIR_AUTHENTICATOR');
+            expect(result.source.config.password).toBeUndefined();
+        });
+
+        it('drops private key credentials when switching to username/password authentication', () => {
+            const recipe = {
+                source: {
+                    config: {
+                        private_key: '-----BEGIN PRIVATE KEY-----...',
+                        private_key_password: 'keypass',
+                    },
+                },
+            };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.setValueOnRecipeOverride?.(recipe, 'DEFAULT_AUTHENTICATOR');
+
+            expect(result.source.config.authentication_type).toBe('DEFAULT_AUTHENTICATOR');
+            expect(result.source.config.private_key).toBeUndefined();
+            expect(result.source.config.private_key_password).toBeUndefined();
+        });
+    });
+
+    describe('getSnowflakeAuthTypeFromRecipe', () => {
+        it('infers DEFAULT_AUTHENTICATOR when only a password is set', () => {
+            const recipe = { source: { config: { password: 'secret' } } };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.getValueFromRecipeOverride?.(recipe);
+
+            expect(result).toBe('DEFAULT_AUTHENTICATOR');
+        });
+
+        it('defaults to KEY_PAIR_AUTHENTICATOR for a new (empty) recipe', () => {
+            const recipe = { source: { config: {} } };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.getValueFromRecipeOverride?.(recipe);
+
+            expect(result).toBe('KEY_PAIR_AUTHENTICATOR');
+        });
+    });
+});
+
+describe('Snowflake (legacy ingest) credential field visibility', () => {
+    it('hides private key fields when authentication type is DEFAULT_AUTHENTICATOR', () => {
+        const values = { authentication_type: 'DEFAULT_AUTHENTICATOR' };
+
+        expect(SNOWFLAKE_PRIVATE_KEY.shouldShow?.(values)).toBe(false);
+        expect(SNOWFLAKE_PRIVATE_KEY_PASSWORD.shouldShow?.(values)).toBe(false);
+    });
+
+    it('shows private key fields when authentication type is KEY_PAIR_AUTHENTICATOR', () => {
+        const values = { authentication_type: 'KEY_PAIR_AUTHENTICATOR' };
+
+        expect(SNOWFLAKE_PRIVATE_KEY.shouldShow?.(values)).toBe(true);
+        expect(SNOWFLAKE_PRIVATE_KEY_PASSWORD.shouldShow?.(values)).toBe(true);
+    });
+});

--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/snowflake.ts
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/snowflake.ts
@@ -1,4 +1,4 @@
-import { get, omit } from 'lodash';
+import { get, omit, set } from 'lodash';
 
 import { FieldType, RecipeField } from '@app/ingest/source/builder/RecipeForm/common';
 
@@ -9,25 +9,27 @@ const privateKeyFieldPath = 'source.config.private_key';
 const privateKeyPasswordFieldPath = 'source.config.private_key_password';
 
 /**
- * Cleans up stale authentication credentials when switching authentication types.
- * This prevents both password and private key from being submitted together.
+ * Writes the selected authentication type to the recipe and clears stale credentials
+ * belonging to the other auth type. Without setting the field explicitly, the YAML
+ * recipe would omit `authentication_type` and Snowflake would fall back to the
+ * default authenticator regardless of the user's selection.
  *
  * @param recipe - The current recipe configuration
- * @returns Updated recipe with only relevant credentials for the selected auth type
+ * @param value - The authentication type selected in the form
+ * @returns Updated recipe with the new auth type and only its relevant credentials
  */
-function setSnowflakeAuthTypeOnRecipe(recipe: any): any {
-    let updatedRecipe = { ...recipe };
-    const authType = get(updatedRecipe, authTypeFieldPath);
+function setSnowflakeAuthTypeOnRecipe(recipe: any, value: string | undefined): any {
+    let updatedRecipe = set({ ...recipe }, authTypeFieldPath, value);
 
     const passwordFields = [passwordFieldPath];
     const keyPairFields = [privateKeyFieldPath, privateKeyPasswordFieldPath];
 
     // Remove password when using key pair authentication
-    if (authType === 'KEY_PAIR_AUTHENTICATOR') {
+    if (value === 'KEY_PAIR_AUTHENTICATOR') {
         updatedRecipe = omit(updatedRecipe, passwordFields);
     }
     // Remove key pair credentials when using username/password authentication
-    else if (authType === 'DEFAULT_AUTHENTICATOR') {
+    else if (value === 'DEFAULT_AUTHENTICATOR') {
         updatedRecipe = omit(updatedRecipe, keyPairFields);
     }
     // For any other auth type or undefined, clean up all credential fields

--- a/datahub-web-react/src/app/ingest/source/builder/sources.json
+++ b/datahub-web-react/src/app/ingest/source/builder/sources.json
@@ -44,7 +44,7 @@
         "displayName": "Snowflake",
         "description": "Import Tables, Views, Databases, Schemas, lineage, queries, and statistics from Snowflake.",
         "docsUrl": "https://docs.datahub.com/docs/quick-ingestion-guides/snowflake/overview",
-        "recipe": "source: \n    type: snowflake\n    config:\n        account_id: null\n        include_table_lineage: true\n        include_view_lineage: true\n        include_tables: true\n        include_views: true\n        profiling:\n            enabled: true\n            profile_table_level_only: true\n        stateful_ingestion:\n            enabled: true"
+        "recipe": "source: \n    type: snowflake\n    config:\n        account_id: null\n        authentication_type: KEY_PAIR_AUTHENTICATOR\n        include_table_lineage: true\n        include_view_lineage: true\n        include_tables: true\n        include_views: true\n        profiling:\n            enabled: true\n            profile_table_level_only: true\n        stateful_ingestion:\n            enabled: true"
     },
     {
         "urn": "urn:li:dataPlatform:starrocks",

--- a/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/__tests__/snowflake.test.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/__tests__/snowflake.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    SNOWFLAKE_AUTHENTICATION_TYPE,
+    SNOWFLAKE_PASSWORD,
+    SNOWFLAKE_PRIVATE_KEY,
+    SNOWFLAKE_PRIVATE_KEY_PASSWORD,
+} from '@app/ingestV2/source/builder/RecipeForm/snowflake';
+
+describe('Snowflake authentication type helpers', () => {
+    describe('setSnowflakeAuthTypeOnRecipe', () => {
+        it('writes KEY_PAIR_AUTHENTICATOR into the recipe when Private Key is selected', () => {
+            const recipe = {
+                source: {
+                    config: {
+                        account_id: 'xyz123',
+                    },
+                },
+            };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.setValueOnRecipeOverride?.(recipe, 'KEY_PAIR_AUTHENTICATOR');
+
+            expect(result.source.config.authentication_type).toBe('KEY_PAIR_AUTHENTICATOR');
+        });
+
+        it('writes DEFAULT_AUTHENTICATOR into the recipe when Username & Password is selected', () => {
+            const recipe = {
+                source: {
+                    config: {
+                        account_id: 'xyz123',
+                    },
+                },
+            };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.setValueOnRecipeOverride?.(recipe, 'DEFAULT_AUTHENTICATOR');
+
+            expect(result.source.config.authentication_type).toBe('DEFAULT_AUTHENTICATOR');
+        });
+
+        it('drops password credentials when switching to key pair authentication', () => {
+            const recipe = {
+                source: {
+                    config: {
+                        password: 'secret',
+                    },
+                },
+            };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.setValueOnRecipeOverride?.(recipe, 'KEY_PAIR_AUTHENTICATOR');
+
+            expect(result.source.config.authentication_type).toBe('KEY_PAIR_AUTHENTICATOR');
+            expect(result.source.config.password).toBeUndefined();
+        });
+
+        it('drops private key credentials when switching to username/password authentication', () => {
+            const recipe = {
+                source: {
+                    config: {
+                        private_key: '-----BEGIN PRIVATE KEY-----...',
+                        private_key_password: 'keypass',
+                    },
+                },
+            };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.setValueOnRecipeOverride?.(recipe, 'DEFAULT_AUTHENTICATOR');
+
+            expect(result.source.config.authentication_type).toBe('DEFAULT_AUTHENTICATOR');
+            expect(result.source.config.private_key).toBeUndefined();
+            expect(result.source.config.private_key_password).toBeUndefined();
+        });
+
+        it('preserves unrelated config fields', () => {
+            const recipe = {
+                source: {
+                    config: {
+                        account_id: 'xyz123',
+                        warehouse: 'COMPUTE_WH',
+                        username: 'snowflake',
+                    },
+                },
+            };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.setValueOnRecipeOverride?.(recipe, 'KEY_PAIR_AUTHENTICATOR');
+
+            expect(result.source.config.account_id).toBe('xyz123');
+            expect(result.source.config.warehouse).toBe('COMPUTE_WH');
+            expect(result.source.config.username).toBe('snowflake');
+        });
+    });
+
+    describe('getSnowflakeAuthTypeFromRecipe', () => {
+        it('infers DEFAULT_AUTHENTICATOR when only a password is set', () => {
+            const recipe = {
+                source: {
+                    config: {
+                        password: 'secret',
+                    },
+                },
+            };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.getValueFromRecipeOverride?.(recipe);
+
+            expect(result).toBe('DEFAULT_AUTHENTICATOR');
+        });
+
+        it('defaults to KEY_PAIR_AUTHENTICATOR for a new (empty) recipe', () => {
+            const recipe = { source: { config: {} } };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.getValueFromRecipeOverride?.(recipe);
+
+            expect(result).toBe('KEY_PAIR_AUTHENTICATOR');
+        });
+
+        it('returns KEY_PAIR_AUTHENTICATOR when a private key is set', () => {
+            const recipe = {
+                source: {
+                    config: {
+                        private_key: '-----BEGIN PRIVATE KEY-----...',
+                    },
+                },
+            };
+            const result = SNOWFLAKE_AUTHENTICATION_TYPE.getValueFromRecipeOverride?.(recipe);
+
+            expect(result).toBe('KEY_PAIR_AUTHENTICATOR');
+        });
+    });
+});
+
+describe('Snowflake credential field visibility', () => {
+    it('hides the password field when authentication type is KEY_PAIR_AUTHENTICATOR', () => {
+        const values = { authentication_type: 'KEY_PAIR_AUTHENTICATOR' };
+
+        expect(SNOWFLAKE_PASSWORD.dynamicHidden?.(values)).toBe(true);
+        expect(SNOWFLAKE_PRIVATE_KEY.dynamicHidden?.(values)).toBe(false);
+        expect(SNOWFLAKE_PRIVATE_KEY_PASSWORD.dynamicHidden?.(values)).toBe(false);
+    });
+
+    it('hides the private key fields when authentication type is DEFAULT_AUTHENTICATOR', () => {
+        const values = { authentication_type: 'DEFAULT_AUTHENTICATOR' };
+
+        expect(SNOWFLAKE_PASSWORD.dynamicHidden?.(values)).toBe(false);
+        expect(SNOWFLAKE_PRIVATE_KEY.dynamicHidden?.(values)).toBe(true);
+        expect(SNOWFLAKE_PRIVATE_KEY_PASSWORD.dynamicHidden?.(values)).toBe(true);
+    });
+});

--- a/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/snowflake.ts
+++ b/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/snowflake.ts
@@ -1,4 +1,4 @@
-import { get, omit } from 'lodash';
+import { get, omit, set } from 'lodash';
 
 import { FieldType, RecipeField } from '@app/ingestV2/source/builder/RecipeForm/common';
 
@@ -9,25 +9,27 @@ const privateKeyFieldPath = 'source.config.private_key';
 const privateKeyPasswordFieldPath = 'source.config.private_key_password';
 
 /**
- * Cleans up stale authentication credentials when switching authentication types.
- * This prevents both password and private key from being submitted together.
+ * Writes the selected authentication type to the recipe and clears stale credentials
+ * belonging to the other auth type. Without setting the field explicitly, the YAML
+ * recipe would omit `authentication_type` and Snowflake would fall back to the
+ * default authenticator regardless of the user's selection.
  *
  * @param recipe - The current recipe configuration
- * @returns Updated recipe with only relevant credentials for the selected auth type
+ * @param value - The authentication type selected in the form
+ * @returns Updated recipe with the new auth type and only its relevant credentials
  */
-function setSnowflakeAuthTypeOnRecipe(recipe: any): any {
-    let updatedRecipe = { ...recipe };
-    const authType = get(updatedRecipe, authTypeFieldPath);
+function setSnowflakeAuthTypeOnRecipe(recipe: any, value: string | undefined): any {
+    let updatedRecipe = set({ ...recipe }, authTypeFieldPath, value);
 
     const passwordFields = [passwordFieldPath];
     const keyPairFields = [privateKeyFieldPath, privateKeyPasswordFieldPath];
 
     // Remove password when using key pair authentication
-    if (authType === 'KEY_PAIR_AUTHENTICATOR') {
+    if (value === 'KEY_PAIR_AUTHENTICATOR') {
         updatedRecipe = omit(updatedRecipe, passwordFields);
     }
     // Remove key pair credentials when using username/password authentication
-    else if (authType === 'DEFAULT_AUTHENTICATOR') {
+    else if (value === 'DEFAULT_AUTHENTICATOR') {
         updatedRecipe = omit(updatedRecipe, keyPairFields);
     }
     // For any other auth type or undefined, clean up all credential fields

--- a/datahub-web-react/src/app/ingestV2/source/builder/sources.json
+++ b/datahub-web-react/src/app/ingestV2/source/builder/sources.json
@@ -55,7 +55,7 @@
         "displayName": "Snowflake",
         "description": "Import Tables, Views, Databases, Schemas, lineage, queries, and statistics from Snowflake.",
         "docsUrl": "https://docs.datahub.com/docs/quick-ingestion-guides/snowflake/overview",
-        "recipe": "source: \n    type: snowflake\n    config:\n        account_id: null\n        include_table_lineage: true\n        include_view_lineage: true\n        include_tables: true\n        include_views: true\n        profiling:\n            enabled: true\n            profile_table_level_only: true\n        stateful_ingestion:\n            enabled: true",
+        "recipe": "source: \n    type: snowflake\n    config:\n        account_id: null\n        authentication_type: KEY_PAIR_AUTHENTICATOR\n        include_table_lineage: true\n        include_view_lineage: true\n        include_tables: true\n        include_views: true\n        profiling:\n            enabled: true\n            profile_table_level_only: true\n        stateful_ingestion:\n            enabled: true",
         "category": "Data Warehouse",
         "isPopular": true
     },


### PR DESCRIPTION
## Description

Fixes a bug where the Snowflake `authentication_type` field was not being written to the recipe configuration. This caused the YAML recipe to omit the field entirely, resulting in Snowflake falling back to the default authenticator regardless of the user's selection in the form.

## Changes

- Modified `setSnowflakeAuthTypeOnRecipe()` to explicitly write the selected authentication type to the recipe using `lodash.set()`, rather than only reading and cleaning up credentials
- Updated the function signature to accept the selected `value` parameter
- Updated JSDoc to clarify that the function now writes the auth type in addition to cleaning up stale credentials
- Applied identical changes to both `datahub-web-react/src/app/ingest/source/builder/RecipeForm/snowflake.ts` and `datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/snowflake.ts`

## Testing

Added comprehensive unit tests in `snowflake.test.tsx` covering:
- Writing `KEY_PAIR_AUTHENTICATOR` and `DEFAULT_AUTHENTICATOR` to the recipe
- Cleaning up password credentials when switching to key pair authentication
- Cleaning up private key credentials when switching to username/password authentication
- Preserving unrelated config fields during auth type changes
- Inferring authentication type from existing recipe credentials
- Dynamic field visibility based on selected authentication type

All tests pass and validate the fix works correctly.

https://claude.ai/code/session_01DmcfMjCvjz4TdpFw71CvsZ