### PR TITLE
chore(ci): Additional triggers & workflows for CLI release tracking in Linear

### DIFF
--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -3,71 +3,154 @@ name: Linear — Ingestion CLI/PyPI Release Tracking
 # Tracks ingestion releases in the "Ingestion CLI/PyPI Releases" Linear pipeline.
 #
 # Release lifecycle for acryl-datahub PyPI:
-#   1. PRs merge to master continuously        → issues synced to the current in-progress release
-#   2. RC tag published (e.g. v0.3.17.7rc1)   → Linear release moved to "Testing Release" stage
-#   3. Stable tag published (e.g. v0.3.17.7)  → release completed + Linear LLM generates release notes
+#   1. PR merges to master          → issue added to cli-next release (staging area)
+#   2. Any release published (RC or stable) → issue migrated from cli-next to versioned release;
+#                                     RC advances to "Testing Release" stage;
+#                                     stable is completed
+#   3. Release deleted in GitHub    → corresponding Linear release is deleted
 #
 # Manual dispatch supports backfilling past releases and one-off stage overrides.
 #
-# Required secret: LINEAR_ACCESS_KEY
-#   → Copy the pipeline access key from Linear Settings → Releases → "Ingestion CLI/PyPI Releases" → CI setup
+# Required secrets:
+#   LINEAR_ACCESS_KEY     — pipeline access key (Linear Settings → Releases → CI setup).
+#                           Used by linear-release-action. Scoped to release-pipeline ops only.
+#   INGESTION_LINEAR_KEY  — personal API key (already used by pr-to-linear.yml).
+#                           Used for direct GraphQL calls (issueToReleaseCreate,
+#                           issueToReleaseDeleteByIssueAndRelease, releaseDelete, issue lookups)
+#                           — the pipeline access key cannot authorize these.
 
 on:
+  pull_request_target:
+    types: [closed]
+    branches: [master]
+    paths:
+      - "metadata-ingestion/**"
+      - "docs/**"
+
   push:
     branches:
       - master
     paths:
-      # Match the path filters already configured in the Linear pipeline settings
       - "metadata-ingestion/**"
       - "docs/**"
 
   release:
-    types: [published] # fires for both RC and stable GitHub releases
+    types: [published, deleted]
 
   workflow_dispatch:
     inputs:
       command:
-        description: "Release command"
+        description: >
+          Release command. Typical backfill sequence: run sync first to create the
+          release and establish baseline, then update to set the stage, then complete
+          to finalize and trigger Linear AI release notes.
+          1. sync = create release if missing + attach issues from commit history.
+          2. update = advance to a named stage (requires stage field below).
+          3. complete = mark released + trigger Linear AI to generate release notes.
         required: true
         type: choice
         options:
-          - update # advance to a specific stage (e.g. backfill an RC transition)
-          - complete # mark released + trigger Linear LLM release note generation
-      stage:
-        description: 'Stage name — only used with "update" (e.g. "testing release")'
-        required: false
-        type: string
+          - sync
+          - update
+          - complete
       version:
-        description: "Release version (e.g. v0.3.17.7 or v0.3.17.7rc1) — required; used to backfill past releases"
+        description: >
+          Release version matching the GitHub tag exactly, including the v prefix
+          (e.g. v1.5.0.19 or v1.5.0.19rc1). Must match the version stored in Linear.
+          For backfilling: run sync first with this version to create the Linear
+          release, then run update or complete as needed.
         required: true
         type: string
+      stage:
+        description: >
+          Stage name — only used with the update command. Matching is exact first,
+          then case-insensitive with dashes/underscores treated as spaces.
+          Current pipeline stages: Planned, Started, In Progress, Testing Release,
+          Released, Canceled. Example: to mark an RC as under validation, any of
+          "Testing Release", "testing release", "testing-release", or
+          "testing_release" works.
+        required: false
+        type: string
+
+env:
+  CLI_NEXT_RELEASE_ID: "7de48387-0024-4156-9c60-33a237985f65"
+  LINEAR_PIPELINE_ID: "1dded0ef-0a6a-421a-805b-2761579688b4"
 
 jobs:
+  # ── JOB 1: PR MERGED → add associated Linear issue to cli-next ──────────────
+  add-to-cli-next:
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find Linear issue from PR comment
+        id: find-issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Match any team prefix — we track changes touching metadata-ingestion/** regardless
+          # of which Linear team owns the ticket (CAT/OBS/etc. tickets are valid too if the PR
+          # touched ingestion paths)
+          ISSUE=$(gh pr view "$PR_NUMBER" \
+            --repo acryldata/datahub \
+            --json comments \
+            --jq '[.comments[].body | match("Linear: ([A-Z]+-[0-9]+)") | .captures[0].string] | first // ""')
+          echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
+          echo "Found Linear issue: ${ISSUE:-none}"
+
+      - name: Add issue to cli-next release
+        if: steps.find-issue.outputs.issue != ''
+        env:
+          LINEAR_API_KEY: ${{ secrets.INGESTION_LINEAR_KEY }}
+          IDENTIFIER: ${{ steps.find-issue.outputs.issue }}
+        run: |
+          # Resolve identifier (e.g. ING-2504) → internal UUID
+          ISSUE_UUID=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"{ issue(id: \\\"$IDENTIFIER\\\") { id } }\"}" \
+            | jq -r '.data.issue.id // empty')
+
+          if [ -z "$ISSUE_UUID" ]; then
+            echo "Could not resolve $IDENTIFIER — skipping"
+            exit 0
+          fi
+
+          RESULT=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"mutation { issueToReleaseCreate(input: { releaseId: \\\"$CLI_NEXT_RELEASE_ID\\\", issueId: \\\"$ISSUE_UUID\\\" }) { success } }\"}" \
+            | jq -r '.data.issueToReleaseCreate.success')
+
+          echo "Added $IDENTIFIER to cli-next: $RESULT"
+
+  # ── JOB 2: RELEASE PUBLISHED or MANUAL DISPATCH ─────────────────────────────
   linear-release:
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'release' && github.event.action == 'published') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # required — action scans full commit history to find ING-XXXX references
+          fetch-depth: 0 # required — action scans full commit history
 
-      # ── 1. MERGE TO MASTER ──────────────────────────────────────────────────
-      # Scans new commits for ING-XXXX references and adds matching issues to
-      # the current in-progress release (no version needed — attaches to latest open release).
-      # Path filter on the trigger above ensures this only runs for ingestion-relevant commits.
+      # ── 1. MERGE TO MASTER ────────────────────────────────────────────────
       - name: Sync issues on merge to master
         if: github.event_name == 'push'
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
 
-      # ── 2. RC PUBLISHED ─────────────────────────────────────────────────────
-      # Triggered when a pre-release GitHub release is published (tag contains "rc").
-      # Step 1: associate the version + sync any issues not yet captured.
-      # Step 2: advance the release to "Testing Release" stage (RC is in validation).
+      # ── 2. ANY RELEASE PUBLISHED ─────────────────────────────────────────
       - name: Extract version from GitHub release tag
         if: github.event_name == 'release'
         run: echo "RELEASE_VERSION=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
 
+      # RC: sync issues to versioned release + advance to Testing Release stage
       - name: Sync issues on RC publish
         if: github.event_name == 'release' && contains(github.event.release.tag_name, 'rc')
         uses: linear/linear-release-action@v0
@@ -81,15 +164,10 @@ jobs:
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: update
-          stage: testing release # matches the "Testing Release" stage in the Linear pipeline
+          stage: testing release
           version: ${{ env.RELEASE_VERSION }}
 
-      # ── 3. STABLE RELEASE PUBLISHED ─────────────────────────────────────────
-      # Triggered when a stable (non-RC) GitHub release is published — same moment
-      # PyPI publish workflows fire. This is the final state of the release.
-      # Step 1: sync any final issues (e.g. last-minute hotfix commits).
-      # Step 2: complete the release → triggers Linear's LLM to auto-generate release notes
-      #         using the release notes template configured in the pipeline settings.
+      # Stable: sync issues + complete release
       - name: Sync issues on stable release
         if: github.event_name == 'release' && !contains(github.event.release.tag_name, 'rc')
         uses: linear/linear-release-action@v0
@@ -105,11 +183,100 @@ jobs:
           command: complete
           version: ${{ env.RELEASE_VERSION }}
 
-      # ── 4. MANUAL DISPATCH ───────────────────────────────────────────────────
-      # Use cases:
-      #   - Backfill a past release:   command=complete, version=v0.3.17.5
-      #   - Fix a missed RC transition: command=update, stage=testing release, version=v0.3.17.7rc1
-      #   - Manually complete a release that didn't auto-trigger
+      # Both RC and stable: migrate cli-next issues that are confirmed in this release's commit range
+      - name: Migrate issues from cli-next to versioned release
+        if: github.event_name == 'release'
+        env:
+          LINEAR_API_KEY: ${{ secrets.INGESTION_LINEAR_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # 1. Find the Linear release we just created/synced (match by version + pipeline)
+          RELEASE_ID=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"{ releasePipeline(id: \\\"$LINEAR_PIPELINE_ID\\\") { releases(filter: { version: { eq: \\\"$TAG\\\" } }) { nodes { id } } } }\"}" \
+            | jq -r '.data.releasePipeline.releases.nodes[0].id // empty')
+
+          if [ -z "$RELEASE_ID" ]; then
+            echo "Could not find Linear release for $TAG — skipping migration"
+            exit 0
+          fi
+          echo "Linear release ID for $TAG: $RELEASE_ID"
+
+          # 2. Find the previous tag via git ancestry, not chronological order.
+          #    git describe walks the commit graph backwards from TAG^ and finds the
+          #    nearest ancestor tag — correctly handles cherry-pick/backport releases
+          #    (e.g. v1.5.0.13.post3 → v1.5.0.13.post2, not v1.5.0.19 which was
+          #    published around the same time but is on a different branch).
+          PREV_TAG=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null)
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found — cannot determine commit range"
+            exit 0
+          fi
+          echo "Commit range: $PREV_TAG..$TAG"
+
+          # 3. Extract PR numbers from commits actually in this release's range.
+          #    git log --cherry-pick --right-only handles cherry-picks correctly:
+          #    only commits unique to TAG (not already in PREV_TAG) are included.
+          PR_NUMBERS=$(git log "$PREV_TAG".."$TAG" --format="%s" --no-merges \
+            | grep -oE '\(#[0-9]+\)' \
+            | tr -d '(#)')
+
+          if [ -z "$PR_NUMBERS" ]; then
+            echo "No PRs found in range $PREV_TAG..$TAG"
+            exit 0
+          fi
+          echo "PRs in this release: $(echo $PR_NUMBERS | tr '\n' ' ')"
+
+          # 4. Build a set of Linear issue identifiers whose PRs are in this release,
+          #    by reading the "Linear: XXX-NNNN" comment that pr-to-linear.yml posts.
+          #    Accept any team prefix — we track ingestion-path changes regardless of which
+          #    team owns the Linear ticket.
+          ISSUES_IN_RELEASE=""
+          for PR in $PR_NUMBERS; do
+            IDENTIFIER=$(gh pr view "$PR" \
+              --repo acryldata/datahub \
+              --json comments \
+              --jq '[.comments[].body | match("Linear: ([A-Z]+-[0-9]+)") | .captures[0].string] | first // ""' 2>/dev/null)
+            if [ -n "$IDENTIFIER" ]; then
+              ISSUES_IN_RELEASE="$ISSUES_IN_RELEASE $IDENTIFIER"
+            fi
+          done
+
+          if [ -z "$ISSUES_IN_RELEASE" ]; then
+            echo "No Linear issues resolved from PRs in this range"
+            exit 0
+          fi
+          echo "Linear issues confirmed in this release:$ISSUES_IN_RELEASE"
+
+          # 5. Get all issues currently in cli-next
+          CLI_NEXT_ISSUES=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"{ release(id: \\\"$CLI_NEXT_RELEASE_ID\\\") { issues { nodes { id identifier } } } }\"}" \
+            | jq -r '.data.release.issues.nodes[] | .id + " " + .identifier')
+
+          # 6. Migrate only issues that are both in cli-next AND confirmed in this release
+          echo "$CLI_NEXT_ISSUES" | while read UUID IDENTIFIER; do
+            if echo "$ISSUES_IN_RELEASE" | grep -qw "$IDENTIFIER"; then
+              echo "  Migrating $IDENTIFIER..."
+              curl -s -X POST https://api.linear.app/graphql \
+                -H "Authorization: $LINEAR_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d "{\"query\": \"mutation { issueToReleaseCreate(input: { releaseId: \\\"$RELEASE_ID\\\", issueId: \\\"$UUID\\\" }) { success } }\"}" \
+                | jq -r '"    add to versioned: " + (.data.issueToReleaseCreate.success | tostring)'
+              curl -s -X POST https://api.linear.app/graphql \
+                -H "Authorization: $LINEAR_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d "{\"query\": \"mutation { issueToReleaseDeleteByIssueAndRelease(issueId: \\\"$UUID\\\", releaseId: \\\"$CLI_NEXT_RELEASE_ID\\\") { success } }\"}" \
+                | jq -r '"    remove from cli-next: " + (.data.issueToReleaseDeleteByIssueAndRelease.success | tostring)'
+            else
+              echo "  Skipping $IDENTIFIER — not confirmed in $TAG commit range"
+            fi
+          done
+
+      # ── 3. MANUAL DISPATCH ────────────────────────────────────────────────
       - name: Manual release command
         if: github.event_name == 'workflow_dispatch'
         uses: linear/linear-release-action@v0
@@ -118,3 +285,33 @@ jobs:
           command: ${{ inputs.command }}
           stage: ${{ inputs.stage }}
           version: ${{ inputs.version }}
+
+  # ── JOB 3: RELEASE DELETED IN GITHUB → delete corresponding Linear release ─
+  delete-linear-release:
+    if: github.event_name == 'release' && github.event.action == 'deleted'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Linear release for ${{ github.event.release.tag_name }}
+        env:
+          LINEAR_API_KEY: ${{ secrets.INGESTION_LINEAR_KEY }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # 1. Find the Linear release by version
+          RELEASE_ID=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"{ releasePipeline(id: \\\"$LINEAR_PIPELINE_ID\\\") { releases(filter: { version: { eq: \\\"$TAG\\\" } }) { nodes { id } } } }\"}" \
+            | jq -r '.data.releasePipeline.releases.nodes[0].id // empty')
+
+          if [ -z "$RELEASE_ID" ]; then
+            echo "No Linear release found for $TAG — nothing to delete"
+            exit 0
+          fi
+          echo "Deleting Linear release $TAG ($RELEASE_ID)"
+
+          # 2. Delete it
+          curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"mutation { releaseDelete(id: \\\"$RELEASE_ID\\\") { success } }\"}" \
+            | jq -r '"Deleted: " + (.data.releaseDelete.success | tostring)'

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -227,7 +227,7 @@ jobs:
             echo "No PRs found in range $PREV_TAG..$TAG"
             exit 0
           fi
-          echo "PRs in this release: $(echo $PR_NUMBERS | tr '\n' ' ')"
+          echo "PRs in this release: $(echo "$PR_NUMBERS" | tr '\n' ' ')"
 
           # 4. Build a set of Linear issue identifiers whose PRs are in this release,
           #    by reading the "Linear: XXX-NNNN" comment that pr-to-linear.yml posts.
@@ -258,7 +258,7 @@ jobs:
             | jq -r '.data.release.issues.nodes[] | .id + " " + .identifier')
 
           # 6. Migrate only issues that are both in cli-next AND confirmed in this release
-          echo "$CLI_NEXT_ISSUES" | while read UUID IDENTIFIER; do
+          echo "$CLI_NEXT_ISSUES" | while read -r UUID IDENTIFIER; do
             if echo "$ISSUES_IN_RELEASE" | grep -qw "$IDENTIFIER"; then
               echo "  Migrating $IDENTIFIER..."
               curl -s -X POST https://api.linear.app/graphql \


### PR DESCRIPTION
## Summary

Adds automated Linear release tracking for the **Ingestion CLI/PyPI Releases** pipeline. Mimics our existing label-based approach (`CLI-Next` + per-version labels in `datahub-internal-pipelines/scripts/pr_release_tracking/`) with Linear's native Releases feature, driven directly from GitHub events instead of a 12-hour Snowflake polling cycle.

## What this workflow does

### On PR merge to master (paths: `metadata-ingestion/**`, `docs/**`)
- Reads the `Linear: XXX-NNNN` comment posted by `pr-to-linear.yml` on the merged PR
- Resolves the identifier to a Linear issue UUID and attaches it to the `cli-next` release in the pipeline (staging area for "coming soon")
- Accepts any team prefix (ING/CAT/OBS/etc.) — we track changes touching ingestion paths regardless of which Linear team owns the ticket

### On any GitHub release published (RC or stable)
- Creates the versioned Linear release via `linear-release-action sync` if it doesn't already exist
- **RC releases** (tag contains `rc`): advances the Linear release to the `Testing Release` stage
- **Stable releases**: marks the Linear release as complete, which triggers Linear AI to generate release notes from the pipeline's notes template
- Migrates issues from `cli-next` → the versioned release, scoped precisely to **issues whose PRs are confirmed in this release's commit range**:
  - Uses `git describe --tags --abbrev=0 <tag>^` to find the previous tag via git ancestry (not chronological order). This correctly handles cherry-pick/backport releases where `v1.5.0.13.post3` resolves to `v1.5.0.13.post2`, not `v1.5.0.19` which was published around the same time on a different branch
  - Walks `git log <prev>..<this>` to extract PR numbers from commit messages
  - For each PR, reads the `Linear: XXX-NNNN` comment and only migrates issues whose PRs are confirmed in-range
  - Issues in `cli-next` whose PRs are NOT in this release's range remain in `cli-next` for the next release

### On GitHub release deleted
- Looks up the corresponding Linear release by version string in the pipeline
- Calls `releaseDelete` to remove it from Linear so the pipeline stays in sync with GitHub

### Manual dispatch (`workflow_dispatch`)
Exposes `sync`, `update`, and `complete` commands with inline helper text for the correct backfill sequence:
1. `sync` first — creates the Linear release if missing and establishes the commit baseline
2. `update` — advances to a named stage (e.g. `testing release`)
3. `complete` — marks released + triggers Linear AI release notes

Stage matching follows the Linear CLI semantics: exact match first, then case-insensitive with dashes/underscores treated as spaces. So `testing release`, `Testing Release`, `testing-release`, and `testing_release` all resolve to the same stage.

## Two-secret pattern

| Secret | Purpose | Where it's used |
|---|---|---|
| `LINEAR_ACCESS_KEY` | Pipeline access key — scoped to release-pipeline operations only | `linear/linear-release-action@v0` steps |
| `INGESTION_LINEAR_KEY` | Personal API key — already used by `pr-to-linear.yml` | Direct GraphQL calls (`issueToReleaseCreate`, `issueToReleaseDeleteByIssueAndRelease`, `releaseDelete`, issue lookups) — the pipeline access key cannot authorize these |

## Pipeline constants

Hardcoded in the workflow `env:` block:
- `CLI_NEXT_RELEASE_ID` — the permanent `cli-next` staging release in the Ingestion CLI/PyPI Releases pipeline
- `LINEAR_PIPELINE_ID` — the Ingestion CLI/PyPI Releases pipeline ID

## What this replaces

This workflow takes over the CLI release tracking responsibility currently handled by `datahub-internal-pipelines/.github/workflows/pr-release-tracking-daily.yml` and its associated `track_pr_releases.py` / `sync_to_linear_graphql.py` scripts. Those scripts use Linear labels (`CLI-Next`, `v1.5.0.20`) as a proxy for release state and poll Snowflake every 12 hours. The Linear Releases feature gives us native release tracking without the label + Snowflake intermediary.

The OSS and SaaS label tracking in `pr-release-tracking-daily.yml` remains in place — only the CLI tracking is being replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)