### PR TITLE
fix(ingestion): respect sample size env var for per-entry context LossyList

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -186,7 +186,7 @@ class StructuredLogs(Report):
             logger.log(level=level.value, msg=log_content, stacklevel=stacklevel)
 
         if log_key not in entries:
-            context_list: LossyList[str] = LossyList()
+            context_list: LossyList[str] = LossyList(max_elements=entries.max_elements)
             if context is not None:
                 context_list.append(context)
             entries[log_key] = StructuredLogEntry(

--- a/metadata-ingestion/tests/unit/api/test_report_sample_size.py
+++ b/metadata-ingestion/tests/unit/api/test_report_sample_size.py
@@ -31,3 +31,28 @@ class TestReportSampleSizeFromEnvVars:
         assert (
             report._structured_logs._entries[StructuredLogLevel.WARN].max_elements == 75
         )
+
+    def test_context_list_respects_sample_size(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that the per-entry context LossyList respects the sample size env var.
+
+        When multiple datasets share the same error message they are grouped into one
+        StructuredLogEntry. The context list within that entry must honour
+        DATAHUB_REPORT_FAILURE_SAMPLE_SIZE so all affected datasets are visible.
+        """
+        monkeypatch.setenv("DATAHUB_REPORT_FAILURE_SAMPLE_SIZE", "50")
+
+        report = SourceReport()
+        # Log the same error message 30 times with different context values.
+        for i in range(30):
+            report.report_failure(message="Error processing table", context=f"table_{i}")
+
+        failures = report._structured_logs._entries[StructuredLogLevel.ERROR]
+        entry = next(iter(failures.values()))
+        assert entry.context.max_elements == 50, (
+            "context LossyList max_elements should match DATAHUB_REPORT_FAILURE_SAMPLE_SIZE"
+        )
+        assert list(entry.context) == [f"table_{i}" for i in range(30)], (
+            "all 30 context items should be retained (30 < max_elements=50, no sampling)"
+        )


### PR DESCRIPTION
## Summary

The `report_log` method was creating the per-entry context `LossyList` with no `max_elements` argument, causing it to default to 10 regardless of the configured `DATAHUB_REPORT_FAILURE/WARNING/INFO_SAMPLE_SIZE` environment variables.

### The problem

The structured log system has two layers of sampling:

1. **Outer `LossyDict`** — tracks unique error message types. Max size is controlled by the env vars (e.g. `DATAHUB_REPORT_FAILURE_SAMPLE_SIZE`).
2. **Inner `LossyList` per entry** — tracks individual dataset names within each grouped message. This was hardcoded to 10 with no env var override.

When many datasets share the same error message (e.g. a permission error hitting an entire schema), they are grouped into one `StructuredLogEntry`. Only 10 dataset names would appear in the context list even if the env vars were set to a large value. The truncation sentinel `... sampled of N total elements` would still appear.

### The fix

Pass `max_elements=entries.max_elements` when creating the context `LossyList`, so it inherits the same limit as the outer `LossyDict` for that log level. No new configuration is needed. The existing env vars now control both layers.

### Changes

- `source.py`: `LossyList()` replaced with `LossyList(max_elements=entries.max_elements)`
- New test `test_context_list_respects_sample_size` added to `test_report_sample_size.py`

## Testing

All 3 unit tests in `test_report_sample_size.py` pass.