### PR TITLE
feat(oss-release): vendor changelog skill in-repo + optional mark-linear audit

### DIFF
--- a/.agent-skills/generating-datahub-changelog/SKILL.md
+++ b/.agent-skills/generating-datahub-changelog/SKILL.md
@@ -1,0 +1,972 @@
+---
+name: generating-datahub-changelog
+description: Generate changelogs for DataHub repository merges. Use when creating release notes, summarizing weekly/daily changes, preparing internal team updates, or drafting external announcements for customers.
+---
+
+> **Vendored, repo-canonical copy.** Moved into the repo from the `connectors-accelerator`
+> plugin so it is version-controlled and independent of the plugin cache. Script/template/
+> reference paths below are repo-relative (`.agent-skills/generating-datahub-changelog/…`).
+> Entry point: the `/generating-datahub-changelog` slash command
+> (`.claude/commands/generating-datahub-changelog.md`).
+
+You are a product marketer creating changelogs for the DataHub team. Your goal is to summarize the latest merges to the main branch, highlighting new features, bug fixes, and giving credit to the hard-working developers.
+
+**Tone by mode:**
+
+- **Internal**: Witty, enthusiastic, fun - developer in-jokes welcome
+- **External**: Professional, friendly, informative - no internal references
+
+> ⏱️ **Typical execution**: 1-3 minutes for weekly changelog, 5-10 minutes for large releases (50+ PRs)
+
+---
+
+## 🚀 Efficiency Guidelines
+
+**Follow these rules to minimize API calls and token usage:**
+
+| Task                | ✅ DO                                            | ❌ DON'T                        |
+| ------------------- | ------------------------------------------------ | ------------------------------- |
+| Fetch PRs           | Single `gh pr list` to file, then `jq` filter    | Read full JSON into context     |
+| Filter PRs          | Use `jq` to extract only needed fields           | Parse large JSON in LLM context |
+| Linear refs         | Use `extract_linear_refs.py` script              | Manually parse PR bodies        |
+| Customer extraction | Use `extract_customers.py` script                | Manually check each ticket      |
+| Breaking changes    | `grep` for PR numbers in file                    | Read entire file into context   |
+| Linear status       | Batch with `list_issues` OR parallel `get_issue` | Sequential individual calls     |
+| PR statistics       | Use `calculate_merge_stats.py` script            | Calculate manually in context   |
+
+**Token-saving techniques:**
+
+- **Save to /tmp files** - Don't read large JSON into context
+- **Use jq** - Filter and transform JSON outside LLM context
+- **Use scripts** - `extract_linear_refs.py`, `extract_customers.py`, `calculate_merge_stats.py`
+- **Parallel tool calls** - Multiple Linear searches in one message
+
+**Execution order for maximum efficiency:**
+
+1. **One `gh pr list` call** → save to `/tmp/prs_raw.json`
+2. **`jq` filter** → extract only needed fields to `/tmp/prs_filtered.json`
+3. **`extract_linear_refs.py`** → get Linear refs without API calls
+4. **One `grep` call** → check breaking changes
+5. **Parallel Linear searches** → get ticket details
+6. **`extract_customers.py`** → extract customer info from tickets
+7. **`calculate_merge_stats.py`** → compute stats from PR JSON
+
+---
+
+## Quick Start
+
+Most common invocations:
+
+```
+/generating-datahub-changelog weekly                    # Last 7 days, all components, internal
+/generating-datahub-changelog weekly ingestion          # Last 7 days, ingestion only
+/generating-datahub-changelog weekly ingestion external # Last 7 days, ingestion, public-facing
+/generating-datahub-changelog from:v0.15.0              # All changes since tag
+```
+
+---
+
+## Argument Parsing
+
+Parse `$ARGUMENTS` for THREE components:
+
+1. **Selection mode** - Which PRs to include (time-based, PR list, tag range, or date range)
+2. **Filter** - Which folders/components to focus on (optional, defaults to `all`)
+3. **Audience mode** - Internal or external changelog (optional, defaults to `internal`)
+
+**Filter keywords** (recognized anywhere in arguments):
+
+- `ingestion` → filter:ingestion
+- `backend` → filter:backend
+- `frontend` → filter:frontend
+- `graphql` → filter:graphql
+- `docs` → filter:docs
+- `all` → no filtering (explicit)
+
+**Audience keywords** (recognized anywhere in arguments):
+
+- `internal` (default) or `external` - See [Audience Mode](#audience-mode-internal-vs-external) for details
+
+**Examples - all of these work:**
+
+```
+/changelog weekly ingestion                # internal by default
+/changelog weekly ingestion internal       # explicit internal
+/changelog weekly ingestion external       # public-facing changelog
+/changelog last 2 weeks backend external
+/changelog prs:123,456 frontend internal
+/changelog from:v0.15.0 ingestion external
+/changelog last month                      # defaults to all, internal
+/changelog weekly filter:ingestion         # explicit syntax still works
+/changelog 14 filter:custom:smoke-test/    # custom filter requires prefix
+```
+
+---
+
+## Selection Modes
+
+### Mode 1: Time-based (default)
+
+**Keywords:**
+
+- `daily` or no args: PRs merged in the last 24 hours
+- `weekly`: PRs merged in the last 7 days
+- `monthly`: PRs merged in the last 30 days
+
+**Numeric:**
+
+- `<number>`: PRs merged in the last N days (e.g., `14` for 14 days)
+
+**Natural language** (parse these to days):
+
+- `"last 2 weeks"` or `"2 weeks"` → 14 days
+- `"last two weeks"` → 14 days
+- `"last 3 days"` or `"3 days"` → 3 days
+- `"last month"` or `"1 month"` → 30 days
+- `"last 2 months"` → 60 days
+
+**Parsing rules for natural language:**
+
+1. Extract the number (digit or word: one=1, two=2, three=3, etc.)
+2. Extract the unit (day/days, week/weeks, month/months)
+3. Convert to days: weeks×7, months×30
+
+Use `gh pr list` with `--search` to find merged PRs. **Fetch ALL needed fields in a single call** to avoid multiple API requests:
+
+```bash
+gh pr list --repo datahub-project/datahub --state merged --search "merged:>=$(date -v-<N>d +%Y-%m-%d)" --limit 100 --json number,title,author,labels,mergedAt,createdAt,body,reviews
+```
+
+**Why all fields at once**: This single call provides everything needed for:
+
+- PR categorization (title, labels)
+- Linear ticket extraction (body contains ING-XXXX references)
+- PR statistics (createdAt, mergedAt, reviews)
+
+**Do NOT** make separate calls for reviews or merge times - it's all in this response.
+
+### Mode 2: PR List
+
+- `prs:123,456,789`: Specific PR numbers to include
+- Fetch each PR using: `gh pr view <pr> --repo datahub-project/datahub --json number,title,author,labels,body,files`
+
+### Mode 3: Tag Range (for releases)
+
+- `from:<tag>`: All PRs between tag and HEAD (e.g., `from:v0.15.0.1rc13`)
+- `from:<tag1>,to:<tag2>`: PRs between two tags (e.g., `from:v0.15.0.1,to:v0.15.0.2`)
+
+Get PR numbers from git log:
+
+```bash
+# All PRs between tags (no filter)
+git log <from_tag>..<to_ref> --pretty=format:'%s' | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -u
+
+# With folder filter (e.g., ingestion)
+git log <from_tag>..<to_ref> --pretty=format:'%s' -- metadata-ingestion/ metadata-ingestion-modules/ | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -u
+```
+
+### Mode 4: Date Range
+
+- `date:2024-01-01,2024-01-15`: PRs merged between two dates (inclusive)
+- `date:2024-01-01`: PRs merged from date to now
+
+Use `gh pr list` with date search:
+
+```bash
+gh pr list --repo datahub-project/datahub --state merged --search "merged:2024-01-01..2024-01-15" --limit 100 --json number,title,author,labels,mergedAt
+```
+
+---
+
+## Filter Profiles
+
+Filters determine which folders/components to include. **Default is `all` (no filtering).**
+
+### `filter:all` (default)
+
+Include ALL PRs regardless of which files they touch. No filtering applied.
+
+### `filter:ingestion`
+
+Only include PRs with changes in:
+
+- `metadata-ingestion/`
+- `metadata-ingestion-modules/`
+
+### `filter:frontend`
+
+Only include PRs with changes in:
+
+- `datahub-web-react/`
+- `datahub-frontend/`
+
+### `filter:backend`
+
+Only include PRs with changes in:
+
+- `metadata-service/`
+- `metadata-io/`
+- `metadata-models/`
+- `entity-registry/`
+
+### `filter:graphql`
+
+Only include PRs with changes in:
+
+- `datahub-graphql-core/`
+
+### `filter:docs`
+
+Only include PRs with changes in:
+
+- `docs/`
+- `*.md` files
+
+### `filter:custom:<path1>,<path2>`
+
+Custom folder filter. Example: `filter:custom:smoke-test/,docker/`
+
+---
+
+## Applying Filters
+
+### For PR list mode (`prs:...`)
+
+Check each PR's files and filter:
+
+```bash
+gh pr view <pr> --repo datahub-project/datahub --json files --jq '.files[].path' | grep -E '^(<pattern>)' | head -1
+```
+
+If filter is set and PR has no matching files, **skip it**.
+
+### For tag range mode
+
+Filter commits directly in git log:
+
+```bash
+git log <from_tag>..<to_ref> --pretty=format:'%s' -- <folder1>/ <folder2>/ | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -u
+```
+
+### For time-based and date-range modes
+
+First get all PRs, then filter each by checking its files.
+
+---
+
+## Filter Pattern Reference
+
+| Filter      | Grep Pattern                                                          |
+| ----------- | --------------------------------------------------------------------- |
+| `ingestion` | `^(metadata-ingestion\|metadata-ingestion-modules)/`                  |
+| `frontend`  | `^(datahub-web-react\|datahub-frontend)/`                             |
+| `backend`   | `^(metadata-service\|metadata-io\|metadata-models\|entity-registry)/` |
+| `graphql`   | `^datahub-graphql-core/`                                              |
+| `docs`      | `^docs/\|\.md$`                                                       |
+
+## Breaking Change Detection
+
+**IMPORTANT**: Cross-reference PRs with the official breaking changes documentation to identify documented breaking changes.
+
+### Step 1: Fetch the updating-datahub.md file
+
+```bash
+gh api repos/datahub-project/datahub/contents/docs/how/updating-datahub.md --jq '.content' | base64 -d > /tmp/updating-datahub.md
+```
+
+Or use curl:
+
+```bash
+curl -sL https://raw.githubusercontent.com/datahub-project/datahub/master/docs/how/updating-datahub.md > /tmp/updating-datahub.md
+```
+
+### Step 2: Extract PR numbers from relevant sections
+
+The file is organized by version with these sections:
+
+- `## Next` - Unreleased changes (check this for PRs heading to next release)
+- `## X.Y.Z` - Released versions
+
+Each version may contain:
+
+- `### Breaking Changes` - **Priority 1**: Must highlight these
+- `### Potential Downtime` - **Priority 2**: Important for ops teams
+- `### Deprecations` - **Priority 3**: Future breaking changes
+
+### Step 3: Match PRs against breaking changes (OPTIMIZED)
+
+**DO NOT read the entire file**. Use grep to search for specific PR numbers:
+
+```bash
+# Build a pattern from your PR numbers and search directly
+grep -E '#(15862|15859|15828|15819)' /tmp/updating-datahub.md
+```
+
+This is much faster than reading the whole file and parsing it in your context.
+
+**Alternative for all breaking changes in a section:**
+
+```bash
+# Extract PR numbers from Breaking Changes sections
+grep -E '^- #[0-9]+' /tmp/updating-datahub.md | grep -oE '#[0-9]+' | tr -d '#'
+```
+
+Breaking changes format in the file:
+
+```
+- #12345: (Component) Description of breaking change
+```
+
+### Step 4: Enrich breaking change entries
+
+If a PR is found in the breaking changes documentation:
+
+1. **Mark it prominently** with 🚨 in the changelog
+2. **Include the documented description** from updating-datahub.md
+3. **Add component tag** if present (e.g., `(Ingestion)`, `(CLI)`, `(Helm)`)
+4. **Note migration steps** if documented
+
+### Breaking Change Sources (in priority order)
+
+1. **updating-datahub.md** - Official documented breaking changes (highest priority)
+2. **PR labels** - `breaking-change` or `breaking` label
+3. **PR title** - Contains "BREAKING" or "[BREAKING]"
+4. **Commit messages** - Contains "BREAKING CHANGE:" (conventional commits)
+
+---
+
+## Linear Ticket Linking
+
+> **NOTE**: This section only applies to `internal` mode. For `external` changelogs, **skip this entire section** to save API calls and avoid including internal references.
+
+**IMPORTANT**: For each PR in the changelog, search for linked Linear tickets to provide better context about why changes were made.
+
+### How to Find Linked Linear Tickets (OPTIMIZED)
+
+Use a **three-phase strategy** - extract first, then search only when needed:
+
+#### Phase 0: Extract Linear refs from PR bodies (NO API CALLS)
+
+**Do this FIRST** - it's free and often sufficient.
+
+Use the provided script to extract Linear refs from PR bodies:
+
+```bash
+gh pr list --repo datahub-project/datahub --state merged --search "merged:>=DATE" \
+  --json number,body | python3 .agent-skills/generating-datahub-changelog/scripts/extract_linear_refs.py --text
+```
+
+Output:
+
+```
+15862: ING-1282, PLAT-456
+15859: ING-1372, OSS-123
+15828: (none)
+```
+
+The script finds patterns: `ING-\d+`, `OSS-\d+`, `PLAT-\d+`, `CUS-\d+`, `PFP-\d+`
+
+**If you find explicit references, skip Phase 1 and 2 for those PRs!**
+
+#### Phase 1: Search by PR Number (ONLY if no refs found in body)
+
+```
+mcp__plugin_linear_linear__list_issues with query: "<PR_NUMBER>"
+```
+
+**Example**: For PR #15859, search with `query: "15859"`
+
+This finds PR Review tickets that have the PR number in their title/description.
+
+#### Phase 2: Search by Keywords (SELECTIVE - only for important PRs)
+
+**Only do this for:**
+
+- Bug fixes (likely have customer issues)
+- PRs with customer-related keywords in title
+
+**Skip this for:**
+
+- Chore/refactor PRs
+- Documentation updates
+- PRs that already have Linear refs from Phase 0/1
+
+Extract 2-3 key terms from the PR title and search:
+
+```
+mcp__plugin_linear_linear__list_issues with query: "<KEY_TERMS>"
+```
+
+#### Efficiency Summary
+
+| Phase   | When to Use                     | API Calls             |
+| ------- | ------------------------------- | --------------------- |
+| Phase 0 | Always (parse body)             | 0                     |
+| Phase 1 | Only if Phase 0 found nothing   | 1 per PR without refs |
+| Phase 2 | Only for bug fixes without refs | Selective             |
+
+### What Links PRs to Linear Tickets
+
+1. **PR Review tickets** - Auto-created with format `[PR Review] <title>` containing PR link in description
+2. **Customer issues** - Have PR URLs in attachments when fixes are submitted (need keyword search)
+3. **Feature tickets** - Reference PR numbers in description or title
+
+### Processing Search Results
+
+When you find linked Linear issues:
+
+1. **Filter relevant results** - Only include issues that actually reference YOUR PR (not just matching numbers)
+2. **Extract key info**: Issue identifier (e.g., `ING-1372`), title, URL, and status
+3. **Identify issue type**: Customer issue, feature request, bug fix, PR review
+4. **Extract customer information** from multiple sources:
+
+#### Customer Extraction Methods (REQUIRED for internal mode)
+
+**🔴 CRITICAL: Check ALL sources for EVERY Linear ticket found. Missing customer tags is a changelog quality failure.**
+
+---
+
+**Method 1: Ticket identifier prefix (CHECK FIRST - highest signal)**
+`CUS-XXXX` tickets are **ALWAYS** customer-related. This is automatic - no exceptions:
+
+```
+CUS-1234  →  🎫 Customer issue (then extract name from other methods)
+ING-5678  →  May or may not be customer-related (check other methods)
+OSS-9999  →  Usually community, but check for customer links
+```
+
+**Action**: If ticket is `CUS-*`, it MUST get a `🎫 Customer:` tag in output.
+
+---
+
+**Method 2: Labels array**
+Look for customer indicators in the `labels` array:
+
+```json
+"labels": ["Company: Acme", "escalated", "cs-bug"]
+```
+
+**Label patterns to check:**
+
+- `"Company: <name>"` format (e.g., `"Company: Acme"`) - extract name after colon
+- Plain company names (see Known Customers List below)
+- Labels containing `acryl-<customer>` (e.g., `"acryl-acme"`, `"acryl-initech"`)
+- Labels containing customer identifiers (e.g., `"customer-request"`, `"cs-bug"`)
+
+---
+
+**Method 3: Description email domains**
+Parse customer emails from description text. Look for patterns:
+
+- `created by [email@domain.com]`
+- `Reported by: email@domain.com`
+- `from email@domain.com`
+- Any `@company.com` in the text
+
+**Map domain to company using the Known Customers List below.**
+
+---
+
+**Method 4: Zendesk attachments (automatic customer signal)**
+Any ticket with Zendesk links is customer-related:
+
+```json
+"attachments": [{"url": "https://acrylsupport.zendesk.com/..."}]
+```
+
+**Action**: If Zendesk link exists, ticket MUST get a `🎫 Customer:` tag.
+If customer name not found elsewhere, use `🎫 Customer Issue` (from Zendesk)
+
+---
+
+**Method 5: Project name**
+Issues in these projects are customer-related:
+
+- "Customer Issues" → Always customer
+- "Customer Feature Requests" → Always customer
+- "Customer Success" → Always customer
+
+---
+
+### Email Domain → Customer Name Extraction
+
+**Simple rule**: Extract company name from email domain by capitalizing the domain name.
+
+- `@initech.example` → Initech
+- `@contoso.example` → Contoso
+- `@globex.example` → Globex
+
+**Skip generic/personal domains** (not customer-identifiable):
+`@gmail.com`, `@outlook.com`, `@hotmail.com`, `@yahoo.com`, `@icloud.com`, `@protonmail.com`
+
+---
+
+**Priority order for extraction**:
+
+1. CUS- prefix (automatic customer)
+2. Labels with `Company:`
+3. Labels with `acryl-<customer>`
+4. Labels with plain customer name
+5. Description email domain
+6. Zendesk attachments
+7. Project name
+
+**Output format**: Always tag customer issues with `🎫 Customer: <name>` or `🎫 Customer Issue` if name unknown
+
+### Batch Processing for Efficiency
+
+When processing multiple PRs:
+
+1. **Phase 0 (local parsing)**: Extract Linear refs from PR bodies first
+
+   - Parse `body` field for `ING-\d+`, `OSS-\d+`, `CUS-\d+`, `PLAT-\d+`, `PFP-\d+` patterns
+   - Note which PRs have explicit refs (but still search for additional context)
+
+2. **Phase 1 (parallel)**: Search PR numbers for ALL PRs
+
+   - Run `list_issues` queries in parallel with PR numbers
+   - **DO NOT skip PRs with body refs** - there may be additional linked tickets (e.g., CUS- tickets)
+   - This catches PR Review tickets and related customer issues
+
+3. **Phase 2 (features and bug fixes)**: Keyword search for important PRs
+
+   - For `feat(` and `fix(` PRs: Search by 2-3 keywords from title
+   - This catches customer issues that reference features/bugs but not PR numbers
+   - Run searches in parallel
+
+4. **Phase 3 (customer scan)**: For EVERY ticket found, check customer indicators
+
+   - `CUS-*` prefix → automatic customer
+   - Zendesk links → automatic customer
+   - `Company:` labels → extract customer name
+   - Email domains → map to customer name
+   - "Customer Issues" project → customer
+
+5. **Deduplicate results**: Same Linear ticket may appear in multiple phases
+
+**⚠️ IMPORTANT**: The old approach of skipping searches for PRs with body refs caused missed customer connections. Better to make a few extra API calls than miss customer attribution.
+
+### Linear API Fallback
+
+If Linear search fails or times out:
+
+1. **Log the failure** but continue processing
+2. **Mark affected PRs** with `[Linear unavailable]` in internal changelogs
+3. **Output changelog** without Linear context - the changelog is still valuable
+4. **Don't block** the entire changelog for Linear failures
+
+### Fetching Linear Ticket Status (OPTIMIZED)
+
+**IMPORTANT**: Batch status fetching to minimize API calls.
+
+#### Option 1: Use list_issues with query (PREFERRED - fewer calls)
+
+If you have multiple ticket IDs, search for them together:
+
+```
+mcp__plugin_linear_linear__list_issues with query: "ING-1282 OR ING-1372 OR OSS-942"
+```
+
+This returns multiple issues in ONE call, each with their status.
+
+#### Option 2: Parallel get_issue calls (when Option 1 doesn't work)
+
+If you must use individual calls, run them **in parallel** (multiple tool calls in single message):
+
+```
+mcp__plugin_linear_linux__get_issue with id: "ING-1282"
+mcp__plugin_linear_linear__get_issue with id: "ING-1372"
+mcp__plugin_linear_linear__get_issue with id: "OSS-942"
+```
+
+**Run ALL get_issue calls in a single message** - don't wait for each one.
+
+#### Status Mapping
+
+- `Done` → Display as ✅ Done
+- `In Progress` → Display as 🔄 In Progress
+- `Todo` or `Backlog` → Display as 📋 Todo
+- `Canceled` → Display as ❌ Canceled
+
+**Format in changelog**: `[ING-1372](https://linear.app/...) - ✅ Done`
+
+### What to Include in Changelog
+
+For PRs with linked Linear tickets:
+
+- Add Linear ticket link: `([ING-123](https://linear.app/...))`
+- **Add ticket status**: `- ✅ Done` or `- 🔄 In Progress`
+- If customer-related: Note the company/context
+- If part of larger initiative: Note the project name
+
+---
+
+## PR Statistics (Internal Mode Only)
+
+> **NOTE**: This section only applies to `internal` mode. For `external` changelogs, **skip this section**.
+
+Calculate and display PR merge statistics to give insight into team velocity and reviewer contributions.
+
+### Data Source - REUSE INITIAL FETCH
+
+**DO NOT make additional API calls for statistics!**
+
+You already have all the data from your initial PR fetch (see [Mode 1: Time-based](#mode-1-time-based-default)):
+
+```json
+{
+  "number": 15862,
+  "createdAt": "2025-01-05T10:00:00Z",
+  "mergedAt": "2025-01-07T15:30:00Z",
+  "reviews": [{ "author": { "login": "reviewer1" }, "state": "APPROVED" }]
+}
+```
+
+### Using the Stats Script
+
+Use the provided script to calculate stats from PR JSON:
+
+```bash
+gh pr list --repo datahub-project/datahub --state merged --search "merged:>=DATE" \
+  --json number,createdAt,mergedAt,reviews | \
+  python3 .agent-skills/generating-datahub-changelog/scripts/calculate_merge_stats.py
+```
+
+Output:
+
+```
+Median: 3.2 weeks
+Average: 3.9 weeks
+Top Reviewers: @sgomezvillamor (13), @askumar27 (3), @deepgarg760 (2)
+```
+
+The script automatically converts times to human-friendly format per the style guide.
+
+### Calculating Merge Time Statistics
+
+For each PR **included in the changelog**, calculate the time from creation to merge:
+
+```
+merge_time = mergedAt - createdAt (in hours)
+```
+
+Calculate both **median** and **average** to provide robust statistics:
+
+- **Median**: Sort merge times, take middle value (or average of two middle values)
+- **Average**: sum(merge_times) / count(PRs)
+
+The median is more robust against outliers (e.g., a PR that sat open for weeks before merging).
+
+**Display format** (use human-friendly units per style guide):
+
+```
+**Merge Time**: Median 3.2 weeks, Average 3.9 weeks
+```
+
+**Human-friendly conversion** (see DATAHUB_WRITE_STYLE.md for full rules):
+
+- < 48 hours → use hours
+- 2-14 days → use days
+- 2-8 weeks → use weeks
+- > 8 weeks → use months
+
+**Examples**:
+
+- 542 hours → "3.2 weeks" or "22.6 days"
+- 24 hours → "1 day" or "24 hours"
+- 2.5 hours → "2 hours 30 minutes"
+
+**Important**: Only calculate statistics for PRs that are **included in the changelog** (after filtering). This ensures the stats reflect the actual changes being reported, not unrelated PRs.
+
+### Counting Top Reviewers
+
+From the `reviews` array, count APPROVED reviews per reviewer:
+
+```json
+"reviews": [
+  {"author": {"login": "reviewer1"}, "state": "APPROVED"},
+  {"author": {"login": "reviewer2"}, "state": "COMMENTED"}
+]
+```
+
+Only count reviews with `"state": "APPROVED"`.
+
+**Display format**: `**Top Reviewers**: @sgomezvillamor (13), @david-leifker (8), @chriscollins3456 (6)`
+
+Show top 3 reviewers by approval count.
+
+### Processing Steps for PR Statistics
+
+1. Fetch PRs with `--json number,title,createdAt,mergedAt,reviews`
+2. **Use only PRs that are included in the changelog** (after applying any filters)
+3. Calculate merge time for each PR: `(mergedAt - createdAt) / 3600000` (ms to hours)
+4. Sort merge times and calculate **median** (middle value)
+5. Calculate **average** of merge times
+6. Count APPROVED reviews per reviewer login (from changelog PRs only)
+7. Sort reviewers by count, take top 3
+
+---
+
+## Audience Mode: Internal vs External
+
+Two audience modes are supported:
+
+- **`internal`** (default): Full changelog with Linear tickets, customer names, internal context
+- **`external`**: Public-facing changelog, no customer info, no Linear links
+
+**Key difference**: External mode skips Linear API searches entirely for efficiency.
+
+See the template files for detailed include/exclude rules:
+
+- `.agent-skills/generating-datahub-changelog/templates/changelog-internal.md`
+- `.agent-skills/generating-datahub-changelog/templates/changelog-external.md`
+
+---
+
+## Handling Large PR Counts (>30 PRs)
+
+When processing many PRs, adjust your approach to keep the changelog readable:
+
+1. **Group by category** rather than listing individually
+
+   - "12 bug fixes across ingestion connectors"
+   - "8 documentation updates"
+
+2. **Prioritize content**:
+
+   - 🚨 Breaking changes: Always list individually with full details
+   - 🌟 Features: List individually (up to 10), summarize remainder
+   - 🐛 Bug fixes: List critical ones, group minor fixes
+   - 🛠️ Chores/docs: Summarize with counts
+
+3. **Use summary counts**:
+
+   - "Plus 15 additional improvements across the codebase"
+   - "Thanks to 8 contributors this week!"
+
+4. **Still credit contributors**: Even in summary mode, mention all contributor handles
+
+---
+
+## PR Analysis (Optimized Workflow)
+
+**Follow this exact order** for maximum efficiency:
+
+### Step 1: Single PR Fetch (ALL data at once)
+
+```bash
+gh pr list --repo datahub-project/datahub --state merged --search "merged:>=<DATE>" --limit 100 \
+  --json number,title,author,labels,mergedAt,createdAt,body,reviews,files > /tmp/prs_raw.json
+```
+
+This one call gives you EVERYTHING: PR details, bodies (for Linear refs), and review data (for stats).
+
+### Step 2: Filter and Extract Key Fields (USE JQ - saves tokens!)
+
+**Don't read the full JSON into context.** Use jq to extract only what you need:
+
+```bash
+# For ingestion filter - extract minimal fields
+cat /tmp/prs_raw.json | jq '[.[] | select(.files[]?.path | test("^(metadata-ingestion|metadata-ingestion-modules)/")) | {number, title, author: .author.login, labels: [.labels[].name], createdAt, mergedAt}]' > /tmp/prs_filtered.json
+
+# Categorize by title prefix
+cat /tmp/prs_filtered.json | jq 'group_by(.title | if startswith("feat") then "feature" elif startswith("fix") then "fix" elif startswith("docs") then "docs" else "other" end)'
+```
+
+### Step 3: Extract Linear Refs (USE SCRIPT - no API calls)
+
+```bash
+cat /tmp/prs_raw.json | python3 .agent-skills/generating-datahub-changelog/scripts/extract_linear_refs.py --text
+```
+
+Output: `15859: ING-1372` or `15828: (none)`
+
+### Step 4: Breaking Changes Check (one grep)
+
+```bash
+grep -E '#(PR_NUM1|PR_NUM2|PR_NUM3)' /tmp/updating-datahub.md
+```
+
+### Step 5: [Internal only] Linear Searches (COMPREHENSIVE for customer detection)
+
+- **For ALL bug fixes and features**: Search by PR number AND title keywords
+- For chore/doc PRs: Search by PR number only (quick check)
+- Run searches in parallel batches
+
+### Step 6: [Internal only] Customer Scan Phase (MANDATORY)
+
+**This step is CRITICAL - do not skip!**
+
+**Use the customer extraction script** to automate this:
+
+```bash
+# Save Linear tickets to JSON, then extract customers
+echo '<linear_tickets_json>' | python3 .agent-skills/generating-datahub-changelog/scripts/extract_customers.py --text
+```
+
+Output:
+
+```
+ING-1282: Acme (label:Company:)
+CUS-6615: Globex (email:@globex.example) [AUTO:CUS-prefix]
+ING-1304: (no customer)
+```
+
+The script automatically checks (in priority order):
+
+1. `CUS-XXXX` prefix → automatic customer
+2. Labels with `Company:` or `acryl-<customer>`
+3. Email domains in description
+4. Zendesk links in attachments
+5. "Customer Issues" project
+
+Build a customer mapping: `{PR_number: customer_name or null}`
+
+### Step 7: [Internal only] Fetch Linear Status (batch)
+
+- Use `list_issues` with OR query, OR
+- Parallel `get_issue` calls in single message
+
+### Step 8: [Internal only] Calculate Statistics (from Step 1 data)
+
+- Parse `createdAt`/`mergedAt` for merge times
+- Count `reviews` with `state: "APPROVED"` for reviewer stats
+
+### Step 9: [Internal only] Customer Tag Validation (MANDATORY)
+
+Before generating output, verify:
+
+- [ ] All `CUS-XXXX` tickets have `🎫 Customer:` tag
+- [ ] All tickets with Zendesk links have customer tag
+- [ ] All tickets in "Customer Issues" project have customer tag
+      If any are missing, go back and extract customer name or use `🎫 Customer Issue`
+
+### Step 10: Generate Changelog
+
+Apply audience mode rules and output formatted changelog.
+
+## Content Priorities
+
+1. Breaking changes (if any) - MUST be at the top
+2. New connectors
+3. Critical bug fixes
+4. Performance improvements
+5. Developer experience improvements
+6. Documentation updates
+
+## Formatting Guidelines
+
+Now, create a change log summary with the following guidelines:
+
+1. Keep it concise and to the point
+2. Highlight the most important changes first
+3. Group similar changes together (e.g., all new features, all bug fixes)
+4. Include issue references where applicable
+5. Mention the names of contributors, giving them credit for their work
+6. Add a touch of humor or playfulness to make it engaging
+7. Use emojis sparingly to add visual interest
+8. Keep total message under 2000 characters for Discord
+9. Use consistent emoji for each section
+10. Format code/technical terms in backticks
+11. Include PR numbers in parentheses (e.g., "Fixed login bug (#123)")
+
+## Deployment Notes
+
+When relevant, include:
+
+- Database migrations required
+- Environment variable updates needed
+- Manual intervention steps post-deploy
+- Dependencies that need updating
+
+Your final output should be formatted based on the **audience mode**.
+
+**Read the appropriate template file:**
+
+- **Internal mode** (default): Read `.agent-skills/generating-datahub-changelog/templates/changelog-internal.md`
+- **External mode**: Read `.agent-skills/generating-datahub-changelog/templates/changelog-external.md`
+
+The template files contain:
+
+- The exact output format to use
+- What to include/exclude
+- Processing steps specific to that mode
+- Language guidelines
+
+---
+
+## Pre-Output Validation Checklist
+
+Before outputting the final changelog, verify:
+
+- [ ] **Breaking changes at top** (if any exist) - marked with 🚨
+- [ ] **Character count < 2000** for Discord compatibility
+- [ ] **No customer names** in external mode
+- [ ] **No Linear ticket links** (ING-XXXX) in external mode
+- [ ] **All contributors credited** - GitHub handles mentioned
+- [ ] **PR numbers included** for all entries
+- [ ] **Correct template used** - internal vs external format
+- [ ] **[Internal mode]** PR Statistics section included with average merge time and top reviewers
+- [ ] **[Internal mode]** Linear ticket statuses shown (✅/🔄/📋/❌)
+
+### 🔴 Customer Tag Validation (Internal Mode - MANDATORY)
+
+**Before outputting, scan your changelog and verify:**
+
+- [ ] **Every `CUS-XXXX` ticket** has a `🎫 Customer:` tag
+- [ ] **Every ticket with Zendesk link** has a `🎫 Customer:` tag
+- [ ] **Every ticket in "Customer Issues" project** has a `🎫 Customer:` tag
+- [ ] **Every ticket with `Company:` label** has corresponding `🎫 Customer:` tag
+- [ ] **Every ticket with `acryl-<customer>` label** has corresponding `🎫 Customer:` tag
+
+**If ANY customer indicator exists but no `🎫` tag in output:**
+
+1. STOP - do not output yet
+2. Go back to the Linear ticket
+3. Extract customer name using the Known Customers List
+4. Add the `🎫 Customer: <name>` tag
+5. If customer name truly cannot be determined, use `🎫 Customer Issue`
+
+**Common mistakes to avoid:**
+
+- ❌ Seeing `CUS-6615` and not tagging it as customer
+- ❌ Seeing Zendesk link in attachments and not tagging
+- ❌ Seeing `@initech.example` in description and not mapping to Initech
+- ❌ Seeing `project: "Customer Issues"` and not tagging
+
+If any check fails, revise before outputting.
+
+---
+
+## Style Guide Review
+
+Now review the changelog using the `.agent-skills/generating-datahub-changelog/references/DATAHUB_WRITE_STYLE.md` file and go one by one to make sure you are following the style guide. Use multiple agents, run in parallel to make it faster.
+
+Remember, your final output should only include the content within the <change_log> tags. Do not include any of your thought process or the original data in the output.
+
+## Known Limitations
+
+- **Linear Customer Requests**: The `customerNeeds` field is not accessible via MCP - use `Company:` labels as workaround
+- **PR fetch limit**: Maximum 100 PRs fetched per query (GitHub API limit) - pagination not implemented
+- **Repository hardcoded**: Currently only works with `datahub-project/datahub` repository
+- **Date command syntax**: Uses macOS `date -v` syntax - may need adjustment for Linux
+
+## Error Handling
+
+- If no changes in the time period, post a "quiet day" message: "🌤️ Quiet day! No new changes merged."
+- If unable to fetch PR details, list the PR numbers for manual review
+- Always validate message length before posting to Discord (max 2000 chars)
+
+## Schedule Recommendations
+
+- Run daily at 6 AM NY time for previous day's changes
+- Run weekly summary on Mondays for the previous week
+- Special runs after major releases or deployments
+
+## Audience Considerations
+
+Adjust the tone and detail level based on the channel:
+
+- **Dev team channels**: Include technical details, performance metrics, code snippets
+- **Product team channels**: Focus on user-facing changes and business impact
+- **Leadership channels**: Highlight progress on key initiatives and blockers

--- a/.agent-skills/generating-datahub-changelog/references/DATAHUB_WRITE_STYLE.md
+++ b/.agent-skills/generating-datahub-changelog/references/DATAHUB_WRITE_STYLE.md
@@ -1,0 +1,372 @@
+# DataHub Writing Style Guide
+
+This style guide ensures consistency across DataHub documentation, changelogs, release notes, and communications. Follow these guidelines for all written content.
+
+---
+
+## Basic Principles
+
+- **Clarity over cleverness**: Technical accuracy comes first. Be precise.
+- **Active voice**: "The connector extracts metadata" not "Metadata is extracted by the connector."
+- **Concise**: Respect the reader's time. Cut unnecessary words.
+- **Scannable**: Use headers, bullets, and formatting to aid quick reading.
+
+---
+
+## Product & Company References
+
+### DataHub Terminology
+
+| Correct                            | Incorrect                                |
+| ---------------------------------- | ---------------------------------------- |
+| DataHub                            | Datahub, Data Hub, datahub               |
+| Acryl Data                         | Acryl, AcrylData                         |
+| GMS (Generalized Metadata Service) | gms, Gms                                 |
+| MCE (Metadata Change Event)        | mce                                      |
+| MCL (Metadata Change Log)          | mcl                                      |
+| URN                                | Urn, urn (when referring to the concept) |
+
+### Entity Names (Always Capitalize)
+
+- Dataset, DataJob, DataFlow, Dashboard, Chart
+- CorpUser, CorpGroup, Domain, Glossary Term
+- Tag, Container, Schema Field
+
+### Connector/Source Names
+
+Use the canonical name from the source system:
+
+- **Correct**: Snowflake, BigQuery, dbt, Kafka, Looker, Tableau
+- **Incorrect**: snowflake, Big Query, DBT, kafka
+
+### Aspect Names
+
+Use PascalCase when referring to aspects:
+
+- SchemaMetadata, Ownership, GlobalTags, GlossaryTerms
+- DatasetProperties, Status, BrowsePathsV2
+
+---
+
+## Grammar & Mechanics
+
+### Abbreviations
+
+- Spell out on first use: "Change Data Capture (CDC)"
+- Common tech abbreviations need no expansion: API, SQL, JSON, YAML, CLI
+- DataHub-specific: Always expand URN, MCE, MCL, GMS on first use per document
+
+### Contractions
+
+- **Documentation**: Avoid contractions (use "do not" not "don't")
+- **Changelogs/Release Notes**: Contractions acceptable for conversational tone
+- **Error Messages**: No contractions
+
+### Oxford Comma
+
+Always use the Oxford comma:
+
+- **Correct**: "Snowflake, BigQuery, and Redshift"
+- **Incorrect**: "Snowflake, BigQuery and Redshift"
+
+---
+
+## Capitalization
+
+### General Rules
+
+- Sentence case for headings: "How to configure the Snowflake connector"
+- Title case for proper nouns and product names only
+- Never ALL CAPS except for acronyms (API, SQL, URN)
+
+### Technical Terms
+
+| Capitalize               | Lowercase                 |
+| ------------------------ | ------------------------- |
+| Python, Java, TypeScript | boolean, string, integer  |
+| Kafka, Elasticsearch     | schema, table, column     |
+| GraphQL, REST            | endpoint, query, mutation |
+| Docker, Kubernetes       | container, pod, service   |
+
+### Feature Names
+
+Capitalize DataHub feature names:
+
+- Lineage, Ownership, Glossary, Domains
+- Assertions, Incidents, Data Contracts
+- Ingestion, Actions, Search
+
+---
+
+## Punctuation
+
+### Dashes
+
+- **Em dash (—)**: For breaks in thought—use sparingly
+- **En dash (–)**: For ranges (v0.10.0–v0.12.0)
+- **Hyphen (-)**: For compound modifiers (real-time processing, event-driven architecture)
+
+### Code References
+
+- Use backticks for: file names, config keys, CLI commands, code snippets
+- Examples: `datahub ingest`, `platform_instance`, `schema.yml`
+
+### Lists
+
+- Use periods for complete sentences
+- No periods for fragments or single items
+- Maintain parallel structure
+
+**Correct**:
+
+```
+Features:
+- Automatic schema detection
+- Incremental extraction
+- Lineage capture
+```
+
+**Incorrect**:
+
+```
+Features:
+- Automatically detects schema.
+- Incremental extraction
+- It captures lineage
+```
+
+---
+
+## Numbers
+
+### Spelling Out
+
+- Spell out one through nine
+- Use numerals for 10 and above
+- Always use numerals with units: "5 MB", "3 seconds", "2 retries"
+
+### Versions
+
+- Use semantic versioning format: v0.14.0, not v0.14 or 0.14.0
+- Version ranges: v0.10.0–v0.12.0
+
+### Percentages
+
+- Use numerals with percent symbol: 50%, not fifty percent
+- No space between number and %
+
+### Time Durations (Human-Friendly Format)
+
+Always convert raw timestamps to the most readable unit. Use the largest appropriate unit that keeps the number between 1-100.
+
+| Raw Value    | Human-Friendly         | Avoid              |
+| ------------ | ---------------------- | ------------------ |
+| 0.5 hours    | 30 minutes             | 0.5 hours          |
+| 2.5 hours    | 2 hours 30 minutes     | 2.5 hours          |
+| 48 hours     | 2 days                 | 48 hours           |
+| 168 hours    | 1 week                 | 168 hours, 7 days  |
+| 542 hours    | 3.2 weeks or 22.6 days | 542 hours          |
+| 720 hours    | 1 month                | 720 hours, 30 days |
+| 90 seconds   | 1.5 minutes            | 90 seconds         |
+| 3600 seconds | 1 hour                 | 3600 seconds       |
+
+**Conversion rules:**
+
+- < 1 hour → use minutes
+- 1-48 hours → use hours (or hours + minutes for precision)
+- 2-14 days → use days
+- 2-8 weeks → use weeks
+- > 8 weeks → use months
+
+**For statistics (median, average):**
+
+- Round to one decimal place: "3.2 weeks" not "3.2142857 weeks"
+- Provide context when helpful: "3.2 weeks (22.6 days)"
+
+**Examples in changelogs:**
+
+- **Merge Time**: Median 3.2 weeks, Average 3.9 weeks
+- **Response time improved**: from 450ms to 120ms
+- **Job duration**: 2 hours 15 minutes
+
+---
+
+## Changelog & Release Notes Style
+
+### Tone
+
+- Conversational but professional
+- Celebrate contributions without being excessive
+- Focus on user impact, not implementation details
+
+### Structure
+
+```markdown
+## 🌟 New Features
+
+- **Feature Name** - Brief description of user benefit (#PR)
+
+## 🐛 Bug Fixes
+
+- **Area** - What was broken and now works (#PR)
+
+## 📚 Documentation
+
+- Description of doc improvement (#PR)
+```
+
+### PR References
+
+- Always include PR numbers: (#15787)
+- Credit contributors: @username
+- Group related changes
+
+### Emojis (Changelogs Only)
+
+| Section          | Emoji |
+| ---------------- | ----- |
+| Breaking Changes | 🚨    |
+| New Features     | 🌟    |
+| Bug Fixes        | 🐛    |
+| Documentation    | 📚    |
+| DevOps/CI        | 🔧    |
+| Security         | 🔒    |
+| Performance      | ⚡    |
+| Deprecation      | ⚠️    |
+
+---
+
+## Technical Documentation Style
+
+### Code Examples
+
+- Always provide working examples
+- Include comments explaining non-obvious parts
+- Show both minimal and complete configurations
+
+```yaml
+# Minimal configuration
+source:
+  type: snowflake
+  config:
+    account_id: "xy12345.us-east-1"
+
+# Complete configuration with all options
+source:
+  type: snowflake
+  config:
+    account_id: "xy12345.us-east-1"
+    platform_instance: "production"  # Optional: disambiguate multiple Snowflake accounts
+    include_table_lineage: true      # Default: true
+```
+
+### Configuration Documentation
+
+- Document every config option
+- Show type and default value
+- Explain when/why to use each option
+
+### Error Messages
+
+- Start with what went wrong
+- Explain why it happened
+- Suggest how to fix it
+
+**Good**: "Connection failed: Unable to reach Snowflake at xy12345.us-east-1. Verify your account_id is correct and your network allows outbound connections on port 443."
+
+**Bad**: "Error: Connection failed"
+
+---
+
+## Words & Phrases
+
+### Preferred Terms
+
+| Use       | Avoid                               |
+| --------- | ----------------------------------- |
+| connector | source (when referring to the code) |
+| ingest    | pull, fetch, sync                   |
+| emit      | push, send                          |
+| entity    | object, item                        |
+| aspect    | attribute, property                 |
+| configure | setup, set up (as verb)             |
+| metadata  | meta-data, meta data                |
+
+### Avoid These
+
+- "Simply" / "Just" / "Easy" - What's easy for you may not be for others
+- "Obviously" / "Clearly" - If it were obvious, you wouldn't need to write it
+- "Please note that" - Just state the information
+- "In order to" - Use "to"
+- "Utilize" - Use "use"
+
+### Connector States
+
+- **Running**: Currently executing
+- **Succeeded**: Completed successfully
+- **Failed**: Completed with errors
+- **Cancelled**: Stopped by user
+- **Pending**: Waiting to start
+
+---
+
+## Links
+
+### Internal Links
+
+- Use relative paths for docs: `../architecture/architecture.md`
+- Link to specific sections: `#configuration-options`
+
+### External Links
+
+- Use descriptive text, not URLs: "[Snowflake documentation](https://docs.snowflake.com)" not "https://docs.snowflake.com"
+- Keep link text 2-5 words
+- Open external links in new tab (when platform supports)
+
+### PR and Issue Links (Changelogs)
+
+**Always use short, friendly link names** - never bare URLs:
+
+| Link Type     | ✅ Correct                                                      | ❌ Avoid                                              |
+| ------------- | --------------------------------------------------------------- | ----------------------------------------------------- |
+| GitHub PR     | [#15859](https://github.com/datahub-project/datahub/pull/15859) | https://github.com/datahub-project/datahub/pull/15859 |
+| Linear ticket | [ING-1282](https://linear.app/acryl-data/issue/ING-1282)        | https://linear.app/acryl-data/issue/ING-1282          |
+| GitHub issue  | [#1234](https://github.com/org/repo/issues/1234)                | Full URL                                              |
+| Zendesk       | [Ticket #5977](https://support.zendesk.com/...)                 | Full URL                                              |
+
+**Format patterns:**
+
+- GitHub PRs: `[#NUMBER](url)` - e.g., `[#15859](https://...)`
+- Linear tickets: `[IDENTIFIER](url)` - e.g., `[ING-1282](https://...)`
+- Keep the identifier as the link text, not a description
+
+**Examples in changelogs:**
+
+```markdown
+✅ Fixed DB2 ARM compatibility ([#15859](https://github.com/...)) - [ING-1372](https://linear.app/...)
+❌ Fixed DB2 ARM compatibility (https://github.com/datahub-project/datahub/pull/15859)
+```
+
+---
+
+## Inclusive Language
+
+- Use "they/them" for unknown individuals
+- Avoid gendered language: "the user...they" not "the user...he"
+- Use "allowlist/denylist" not "whitelist/blacklist"
+- Use "primary/replica" not "master/slave"
+
+---
+
+## Quick Reference
+
+### Before Publishing Checklist
+
+- [ ] Product names capitalized correctly (DataHub, not Datahub)
+- [ ] Connector names match source system (BigQuery, not Big Query)
+- [ ] Code in backticks
+- [ ] PR numbers included for changelogs
+- [ ] No "simply" or "just"
+- [ ] Active voice used
+- [ ] Oxford commas present
+- [ ] Links are descriptive, not bare URLs

--- a/.agent-skills/generating-datahub-changelog/references/DATAHUB_WRITE_STYLE.md
+++ b/.agent-skills/generating-datahub-changelog/references/DATAHUB_WRITE_STYLE.md
@@ -202,6 +202,10 @@ Always convert raw timestamps to the most readable unit. Use the largest appropr
 ### Structure
 
 ```markdown
+## 🚨 Breaking Changes
+
+- 🚨 **PR #XXXX** (Component): What changed and the migration step (#PR)
+
 ## 🌟 New Features
 
 - **Feature Name** - Brief description of user benefit (#PR)
@@ -210,9 +214,9 @@ Always convert raw timestamps to the most readable unit. Use the largest appropr
 
 - **Area** - What was broken and now works (#PR)
 
-## 📚 Documentation
+## 🛠️ Other Improvements
 
-- Description of doc improvement (#PR)
+- **Area** - Improvement and its benefit (#PR)
 ```
 
 ### PR References

--- a/.agent-skills/generating-datahub-changelog/scripts/calculate_merge_stats.py
+++ b/.agent-skills/generating-datahub-changelog/scripts/calculate_merge_stats.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Calculate PR merge time statistics from GitHub PR JSON data.
+
+Usage:
+    # From gh pr list JSON output:
+    gh pr list --repo datahub-project/datahub --state merged --json number,createdAt,mergedAt,reviews | python calculate_merge_stats.py
+
+    # Or with a file:
+    python calculate_merge_stats.py < prs.json
+
+    # Or with inline JSON:
+    echo '[{"number": 123, "createdAt": "2025-01-01T00:00:00Z", "mergedAt": "2025-01-02T00:00:00Z", "reviews": []}]' | python calculate_merge_stats.py
+
+Output:
+    Median: X.X days/weeks
+    Average: Y.Y days/weeks
+    Top Reviewers: @user1 (N), @user2 (N), @user3 (N)
+"""
+
+import json
+import sys
+from datetime import datetime
+from collections import Counter
+
+
+def humanize_hours(hours: float) -> str:
+    """Convert hours to human-friendly format per style guide."""
+    if hours < 48:
+        return f"{hours:.1f} hours"
+    elif hours < 336:  # 2 weeks
+        return f"{hours/24:.1f} days"
+    else:
+        return f"{hours/168:.1f} weeks"
+
+
+def calculate_merge_times(prs: list) -> tuple[float, float]:
+    """Calculate median and average merge times in hours."""
+    merge_hours = []
+
+    for pr in prs:
+        created = pr.get("createdAt")
+        merged = pr.get("mergedAt")
+
+        if not created or not merged:
+            continue
+
+        c = datetime.fromisoformat(created.replace("Z", "+00:00"))
+        m = datetime.fromisoformat(merged.replace("Z", "+00:00"))
+        hours = (m - c).total_seconds() / 3600
+        merge_hours.append(hours)
+
+    if not merge_hours:
+        return 0.0, 0.0
+
+    merge_hours.sort()
+    n = len(merge_hours)
+
+    # Calculate median
+    if n % 2 == 0:
+        median = (merge_hours[n//2 - 1] + merge_hours[n//2]) / 2
+    else:
+        median = merge_hours[n//2]
+
+    # Calculate average
+    avg = sum(merge_hours) / n
+
+    return median, avg
+
+
+def count_reviewers(prs: list, top_n: int = 3) -> list[tuple[str, int]]:
+    """Count approved reviews per reviewer."""
+    reviewer_counts = Counter()
+
+    for pr in prs:
+        reviews = pr.get("reviews", [])
+        for review in reviews:
+            if review.get("state") == "APPROVED":
+                author = review.get("author", {})
+                login = author.get("login") if isinstance(author, dict) else None
+                if login:
+                    reviewer_counts[login] += 1
+
+    return reviewer_counts.most_common(top_n)
+
+
+def main():
+    # Read JSON from stdin
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(data, list):
+        print("Error: Expected JSON array of PRs", file=sys.stderr)
+        sys.exit(1)
+
+    if not data:
+        print("No PRs provided")
+        sys.exit(0)
+
+    # Calculate merge times
+    median, avg = calculate_merge_times(data)
+
+    # Count reviewers
+    top_reviewers = count_reviewers(data)
+
+    # Output results
+    print(f"Median: {humanize_hours(median)}")
+    print(f"Average: {humanize_hours(avg)}")
+
+    if top_reviewers:
+        reviewer_str = ", ".join(f"@{login} ({count})" for login, count in top_reviewers)
+        print(f"Top Reviewers: {reviewer_str}")
+    else:
+        print("Top Reviewers: (no approved reviews found)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agent-skills/generating-datahub-changelog/scripts/extract_customers.py
+++ b/.agent-skills/generating-datahub-changelog/scripts/extract_customers.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Extract customer information from Linear ticket JSON data.
+
+Usage:
+    # Pipe Linear API JSON output:
+    echo '[{"identifier": "CUS-123", "labels": ["Company: Acme"], ...}]' | python extract_customers.py
+
+    # Or with a file:
+    python extract_customers.py < tickets.json
+
+Output (JSON):
+    {
+      "ING-1282": {"customer": "Acme", "source": "label:Company:"},
+      "CUS-6615": {"customer": "Globex", "source": "email:@globex.example"},
+      "ING-1304": {"customer": null, "source": null}
+    }
+
+Output (text, with --text flag):
+    ING-1282: Acme (label:Company:)
+    CUS-6615: Globex (email:@globex.example)
+    ING-1304: (no customer)
+"""
+
+import json
+import re
+import sys
+
+# Generic email domains to skip
+GENERIC_DOMAINS = {
+    'gmail.com', 'outlook.com', 'hotmail.com', 'yahoo.com',
+    'icloud.com', 'protonmail.com', 'live.com', 'msn.com',
+    'datahub.com', 'acryl.io', 'acryldata.io'  # Internal domains
+}
+
+# Email pattern
+EMAIL_PATTERN = re.compile(r'[\w.+-]+@([\w-]+\.[\w.-]+)')
+
+
+def extract_customer_from_labels(labels: list) -> tuple[str, str] | tuple[None, None]:
+    """Extract customer from labels array."""
+    if not labels:
+        return None, None
+
+    for label in labels:
+        if not isinstance(label, str):
+            # Handle label objects with 'name' field
+            if isinstance(label, dict):
+                label = label.get('name', '')
+            else:
+                continue
+
+        # Check for "Company: X" format
+        if label.startswith('Company:'):
+            customer = label.split(':', 1)[1].strip()
+            return customer, 'label:Company:'
+
+        # Check for "acryl-<customer>" format
+        if label.startswith('acryl-') and label != 'acryl-data':
+            customer = label.replace('acryl-', '').replace('-', ' ').title()
+            return customer, f'label:{label}'
+
+    return None, None
+
+
+def extract_customer_from_email(text: str) -> tuple[str, str] | tuple[None, None]:
+    """Extract customer from email domains in text."""
+    if not text:
+        return None, None
+
+    matches = EMAIL_PATTERN.findall(text)
+    for domain in matches:
+        domain_lower = domain.lower()
+        if domain_lower not in GENERIC_DOMAINS:
+            # Extract company name from domain
+            company = domain.split('.')[0].title()
+            return company, f'email:@{domain_lower}'
+
+    return None, None
+
+
+def extract_customer_from_zendesk(attachments: list) -> tuple[str, str] | tuple[None, None]:
+    """Check if ticket has Zendesk attachments (indicates customer issue)."""
+    if not attachments:
+        return None, None
+
+    for att in attachments:
+        url = att.get('url', '') if isinstance(att, dict) else ''
+        if 'zendesk.com' in url:
+            return '[Zendesk]', 'zendesk'
+
+    return None, None
+
+
+def extract_customer_from_project(project: str) -> tuple[str, str] | tuple[None, None]:
+    """Check if ticket is in a customer project."""
+    if not project:
+        return None, None
+
+    customer_projects = {'Customer Issues', 'Customer Feature Requests', 'Customer Success'}
+    if project in customer_projects:
+        return '[Customer Project]', f'project:{project}'
+
+    return None, None
+
+
+def extract_customer(ticket: dict) -> dict:
+    """Extract customer info from a Linear ticket using priority order."""
+    identifier = ticket.get('identifier', 'unknown')
+
+    # Priority 1: CUS- prefix (automatic customer)
+    if identifier.startswith('CUS-'):
+        # Still try to get actual customer name from other sources
+        customer, source = extract_customer_from_labels(ticket.get('labels', []))
+        if customer:
+            return {'customer': customer, 'source': source, 'auto': 'CUS-prefix'}
+
+        customer, source = extract_customer_from_email(ticket.get('description', ''))
+        if customer:
+            return {'customer': customer, 'source': source, 'auto': 'CUS-prefix'}
+
+        # CUS- but no name found - still mark as customer
+        return {'customer': '[Customer Issue]', 'source': 'CUS-prefix', 'auto': 'CUS-prefix'}
+
+    # Priority 2: Labels with Company: or acryl-
+    customer, source = extract_customer_from_labels(ticket.get('labels', []))
+    if customer:
+        return {'customer': customer, 'source': source, 'auto': None}
+
+    # Priority 3: Email domains in description
+    customer, source = extract_customer_from_email(ticket.get('description', ''))
+    if customer:
+        return {'customer': customer, 'source': source, 'auto': None}
+
+    # Priority 4: Zendesk attachments
+    customer, source = extract_customer_from_zendesk(ticket.get('attachments', []))
+    if customer:
+        return {'customer': customer, 'source': source, 'auto': None}
+
+    # Priority 5: Customer project
+    customer, source = extract_customer_from_project(ticket.get('project', ''))
+    if customer:
+        return {'customer': customer, 'source': source, 'auto': None}
+
+    return {'customer': None, 'source': None, 'auto': None}
+
+
+def main():
+    text_mode = '--text' in sys.argv
+
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Handle single ticket or array
+    if isinstance(data, dict):
+        data = [data]
+
+    if not isinstance(data, list):
+        print("Error: Expected JSON object or array of tickets", file=sys.stderr)
+        sys.exit(1)
+
+    result = {}
+    for ticket in data:
+        identifier = ticket.get('identifier', 'unknown')
+        info = extract_customer(ticket)
+        result[identifier] = info
+
+    if text_mode:
+        for identifier, info in sorted(result.items()):
+            customer = info['customer']
+            source = info['source']
+            auto = info.get('auto')
+
+            if customer:
+                auto_note = f" [AUTO:{auto}]" if auto else ""
+                print(f"{identifier}: {customer} ({source}){auto_note}")
+            else:
+                print(f"{identifier}: (no customer)")
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agent-skills/generating-datahub-changelog/scripts/extract_linear_refs.py
+++ b/.agent-skills/generating-datahub-changelog/scripts/extract_linear_refs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Extract Linear ticket references from GitHub PR JSON data.
+
+Usage:
+    # From gh pr list JSON output:
+    gh pr list --repo datahub-project/datahub --state merged --json number,body | python extract_linear_refs.py
+
+    # Or with a file:
+    python extract_linear_refs.py < prs.json
+
+Output (JSON):
+    {
+      "15859": ["ING-1372"],
+      "15828": ["ING-1282", "OSS-942"],
+      "15862": []
+    }
+
+Output (text, with --text flag):
+    15859: ING-1372
+    15828: ING-1282, OSS-942
+    15862: (none)
+"""
+
+import json
+import re
+import sys
+
+# Pattern to match Linear ticket references
+LINEAR_PATTERN = re.compile(r'\b(ING|OSS|PLAT|CUS|PFP)-\d+\b')
+
+
+def extract_refs(body: str) -> list[str]:
+    """Extract unique Linear refs from text."""
+    if not body:
+        return []
+    matches = LINEAR_PATTERN.findall(body)
+    # findall returns the captured group, reconstruct full match
+    full_matches = LINEAR_PATTERN.finditer(body)
+    refs = sorted(set(match.group(0) for match in full_matches))
+    return refs
+
+
+def main():
+    # Check for --text flag
+    text_mode = '--text' in sys.argv
+
+    # Read JSON from stdin
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON input - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(data, list):
+        print("Error: Expected JSON array of PRs", file=sys.stderr)
+        sys.exit(1)
+
+    result = {}
+    for pr in data:
+        number = str(pr.get("number", "unknown"))
+        body = pr.get("body", "")
+        refs = extract_refs(body)
+        result[number] = refs
+
+    if text_mode:
+        for number, refs in sorted(result.items(), key=lambda x: int(x[0]) if x[0].isdigit() else 0, reverse=True):
+            if refs:
+                print(f"{number}: {', '.join(refs)}")
+            else:
+                print(f"{number}: (none)")
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agent-skills/generating-datahub-changelog/templates/changelog-external.md
+++ b/.agent-skills/generating-datahub-changelog/templates/changelog-external.md
@@ -1,0 +1,92 @@
+# External Changelog Template
+
+Use this template when `external` mode is specified. This is for public-facing changelogs safe to share with customers.
+
+## Output Format
+
+<change_log>
+
+# 🚀 [Daily/Weekly] Change Log: [Current Date]
+
+## 🚨 Breaking Changes (if any)
+
+### Documented Breaking Changes
+
+- 🚨 **PR #XXXX** (Component): Description from updating-datahub.md
+  - Migration: [any documented migration steps]
+
+### Other Breaking Changes
+
+- ⚠️ **PR #XXXX**: Description from PR
+
+## ⏰ Potential Downtime (if any)
+
+[PRs documented in "Potential Downtime" section]
+
+## 🌟 New Features
+
+[List new features with PR numbers - NO Linear links, NO customer references]
+
+- Example: Added exponential backoff for Tableau (#15828)
+- Example: New Snowflake lineage extraction (#15830)
+
+## 🐛 Bug Fixes
+
+[List bug fixes with PR numbers - NO Linear links, NO customer references]
+
+- Example: Fixed DB2 ARM compatibility (#15859)
+- Example: Resolved authentication edge case in BigQuery (#15861)
+
+## 🛠️ Other Improvements
+
+[List other significant changes]
+
+## 🙌 Contributors
+
+[Thank contributors - GitHub handles are public and OK to share]
+
+- @contributor1, @contributor2
+
+</change_log>
+
+## What to Include/Exclude
+
+| Content Type                   | Include?      | Notes                            |
+| ------------------------------ | ------------- | -------------------------------- |
+| PR numbers and GitHub links    | ✅ Yes        | Public repo, OK to share         |
+| Linear ticket links            | ❌ No         | Internal tool                    |
+| Customer names                 | ❌ No         | Never expose who reported issues |
+| Zendesk ticket references      | ❌ No         | Internal support system          |
+| Internal project names         | ❌ No         | Internal planning details        |
+| Breaking change details        | ✅ Yes        | Important for users              |
+| Contributor names              | ✅ Yes        | GitHub handles are public        |
+| Fun facts/humor                | ⚠️ Toned down | Keep professional                |
+| Linear Tickets Summary section | ❌ No         | Skip entire section              |
+
+## Processing Steps
+
+1. **Skip Linear ticket searches entirely** (saves API calls)
+2. Don't look up customer information
+3. Focus only on what the change does, not who requested it
+4. Use simplified output template without Linear section
+5. Remove any customer-identifying information from PR descriptions before including
+
+## Language Adjustments
+
+When writing external changelogs, rephrase internal language:
+
+| Internal                       | External                         |
+| ------------------------------ | -------------------------------- |
+| "Fixed issue reported by Acme" | "Fixed authentication edge case" |
+| "Resolves customer escalation" | "Fixed critical bug"             |
+| "Part of Q1 initiative"        | (omit entirely)                  |
+| "See ING-1234 for details"     | (omit entirely)                  |
+
+## Key Rules
+
+- NO "🎫 Linked Linear Tickets" section
+- NO "🎉 Fun Fact" section (keep it professional)
+- NO customer names or references anywhere
+- NO Linear ticket links (ING-XXXX)
+- NO Zendesk references
+- Keep tone professional but still friendly

--- a/.agent-skills/generating-datahub-changelog/templates/changelog-internal.md
+++ b/.agent-skills/generating-datahub-changelog/templates/changelog-internal.md
@@ -1,0 +1,137 @@
+# Internal Changelog Template
+
+Use this template when `internal` mode is specified or no mode is given.
+
+## Output Format
+
+<change_log>
+
+# 🚀 [Daily/Weekly] Change Log: [Current Date]
+
+## 🚨 Breaking Changes (if any)
+
+### Documented Breaking Changes
+
+[PRs found in updating-datahub.md - include the official description and any migration notes]
+
+- 🚨 **PR #XXXX** (Component): Official description from updating-datahub.md
+  - Migration: [any documented migration steps]
+
+### Other Breaking Changes
+
+[PRs with breaking change labels/titles but not yet documented]
+
+- ⚠️ **PR #XXXX**: Description from PR
+
+## ⏰ Potential Downtime (if any)
+
+[PRs documented in "Potential Downtime" section of updating-datahub.md]
+
+## 🌟 New Features
+
+[List new features here with PR numbers and Linear links if available]
+[For customer-driven features, add a witty comment celebrating the customer win!]
+
+- Example: Added exponential backoff for Tableau ([#15828](https://github.com/datahub-project/datahub/pull/15828)) - [ING-1282](https://linear.app/acryl-data/issue/ING-1282) - 🎫 Acme asked, we delivered!
+- Example: New DB2 connector with full lineage support ([#14968](https://github.com/datahub-project/datahub/pull/14968)) - [CUS-6615](https://linear.app/acryl-data/issue/CUS-6615) - 🎫 Globex's wish is our command!
+
+**Witty customer comment examples** (vary these, be creative!):
+
+- "🎫 [Customer] asked, we delivered!"
+- "🎫 [Customer]'s wish is our command!"
+- "🎫 Another win for [Customer]!"
+- "🎫 [Customer] can finally sleep well!"
+- "🎫 Making [Customer] happy, one PR at a time!"
+- "🎫 [Customer] reported it, we squashed it!"
+
+## 🐛 Bug Fixes
+
+[List bug fixes here with PR numbers and Linear links if available]
+[For customer-reported bugs, add a witty comment acknowledging the fix!]
+
+- Example: Fixed DB2 ARM compatibility ([#15859](https://github.com/datahub-project/datahub/pull/15859)) - [ING-1372](https://linear.app/acryl-data/issue/ING-1372) - 🎫 No more ARM wrestling for Acme!
+- Example: Fixed Snowflake connection timeout ([#15860](https://github.com/datahub-project/datahub/pull/15860)) - [CUS-456](https://linear.app/acryl-data/issue/CUS-456) - 🎫 Hooli's timeouts are history!
+- Example: Fixed query parsing edge case ([#15861](https://github.com/datahub-project/datahub/pull/15861)) - 🎫 Customer issue squashed!
+
+## 🛠️ Other Improvements
+
+[List other significant changes or improvements]
+
+## 📊 PR Statistics
+
+- **Merge Time**: Median X.X days/weeks, Average Y.Y days/weeks _(use human-friendly units per style guide)_
+- **Top Reviewers**: @reviewer1 (N), @reviewer2 (N), @reviewer3 (N)
+
+## 🎫 Linked Linear Tickets
+
+[Summary of Linear tickets addressed by these PRs - separated by type]
+
+**Status icons:**
+
+- ✅ Done/Completed
+- 🔄 In Progress
+- 📋 Todo/Backlog
+- ❌ Canceled
+
+### Customer Issues
+
+[List customer-related tickets with prominent customer attribution]
+Format: `[TICKET-ID](url) - STATUS - 🎫 Customer: NAME - Description → Addressed by #PR`
+
+- Example: [ING-1282](https://linear.app/acryl-data/issue/ING-1282) - 📋 Todo - 🎫 Customer: Acme - Tableau 503 errors → Addressed by #15828
+- Example: [CUS-6615](https://linear.app/acryl-data/issue/CUS-6615) - ✅ Done - 🎫 Customer: Globex - DB2 z/OS guidance → Enabled by #14968
+
+### Internal Issues
+
+[List internal/engineering tickets without customer context]
+Format: `[TICKET-ID](url) - STATUS - Description → Addressed by #PR`
+
+- Example: [ING-1372](https://linear.app/acryl-data/issue/ING-1372) - ✅ Done - DB2 ARM CI build issues → Fixed by #15859
+
+### Feature Requests & Projects
+
+- **Feature Requests Completed**: List feature tickets closed by PRs
+- **Projects Advanced**: Note any project milestones hit
+
+## 🙌 Shoutouts
+
+[Mention contributors and their contributions]
+
+## 🎉 Fun Fact of the Day
+
+[Include a brief, work-related fun fact or joke]
+
+</change_log>
+
+## What to Include
+
+| Content Type                    | Include? | Example                                                  |
+| ------------------------------- | -------- | -------------------------------------------------------- |
+| PR numbers and GitHub links     | ✅ Yes   | ([#15859](https://github.com/.../pull/15859))            |
+| Linear ticket links             | ✅ Yes   | [ING-1372](https://linear.app/acryl-data/issue/ING-1372) |
+| Linear ticket status            | ✅ Yes   | [ING-1372](url) - ✅ Done                                |
+| Customer names (Company: label) | ✅ Yes   | 🎫 Customer: Acme                                        |
+| Customer names (plain label)    | ✅ Yes   | 🎫 Customer: Hooli                                       |
+| **Witty customer comments**     | ✅ Yes   | 🎫 Acme asked, we delivered!                             |
+| CUS-XXXX tickets                | ✅ Yes   | [CUS-456](url) - always customer-related                 |
+| Zendesk ticket references       | ✅ Yes   | 🎫 Customer Issue (from Zendesk)                         |
+| Internal project names          | ✅ Yes   | Part of Q1 Ingestion Initiative                          |
+| Breaking change details         | ✅ Yes   | Full migration steps                                     |
+| Contributor names               | ✅ Yes   | Thanks @john-doe!                                        |
+| Fun facts/humor                 | ✅ Yes   | Developer in-jokes welcome                               |
+| Linear Tickets Summary section  | ✅ Yes   | Full section with customer details                       |
+| PR Statistics section           | ✅ Yes   | Average merge time, top reviewers                        |
+
+## Processing Steps
+
+1. Run Linear ticket searches (both phases)
+2. Extract customer information from Linear tickets
+3. **Fetch Linear ticket status** using `get_issue` for each linked ticket
+4. **Calculate PR statistics**:
+   - Fetch PR data with `createdAt`, `mergedAt`, and `reviews` fields
+   - Calculate average merge time (mergedAt - createdAt) for all PRs
+   - Count APPROVED reviews per reviewer to find top reviewers
+5. Include all internal context
+6. **Add witty customer comments** for customer-driven features and bug fixes in the main sections
+7. **Separate Linear tickets** into Customer Issues vs Internal Issues subsections
+8. Use full output template with Linear section and PR Statistics

--- a/.agent-skills/oss-release/SKILL.md
+++ b/.agent-skills/oss-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oss-release
-description: Cut release candidates and stable releases of the acryl-datahub OSS CLI from the acryldata/datahub fork. Use when running /oss-release rc, /oss-release stable, /oss-release status (also accepts legacy aliases /oss-release prep and /oss-release finish); when cutting a new RC; promoting an RC to stable; previewing a release in dry-run; or checking CI on a release candidate. Handles preflight, upstream diff, structured safety assessment, version bump, changelog generation, stale-notes detection, tag/release publishing, auto-dispatch of the acryldata/connector-tests nightly workflow for the new RC, and gating stable promotion on that run's success (verified by querying GitHub directly — no local state) plus RC-identity verification.
+description: Cut release candidates and stable releases of the acryl-datahub OSS CLI from the acryldata/datahub fork. Use when running /oss-release rc, /oss-release stable, /oss-release status, /oss-release mark-linear (also accepts legacy aliases /oss-release prep and /oss-release finish); when cutting a new RC; promoting an RC to stable; previewing a release in dry-run; checking CI on a release candidate; or running an optional manual audit of the automated Linear release tracking. Handles preflight, upstream diff, structured safety assessment, version bump, changelog generation, stale-notes detection, tag/release publishing, auto-dispatch of the acryldata/connector-tests nightly workflow for the new RC, and gating stable promotion on that run's success (verified by querying GitHub directly — no local state) plus RC-identity verification.
 ---
 
 # OSS CLI Release Skill
@@ -50,11 +50,12 @@ own paths internally via `$(dirname "$0")`.
 
 ## Subcommands
 
-| Subcommand | Aliases  | Purpose                                                                                  | Time    | Workflow file                  |
-| ---------- | -------- | ---------------------------------------------------------------------------------------- | ------- | ------------------------------ |
-| `rc`       | `prep`   | Diff analysis → safety check → changelog → cut RC pre-release → dispatch connector tests | ~5 min  | `workflows/prep.md`            |
-| `stable`   | `finish` | Check CI + connector tests on latest RC → confirm → cut stable release                   | async   | `workflows/finish.md`          |
-| `status`   | —        | Show CI + connector-tests status for the latest RC, no action taken                      | instant | `workflows/finish.md` (bottom) |
+| Subcommand    | Aliases  | Purpose                                                                                                                                                                                      | Time    | Workflow file                      |
+| ------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
+| `rc`          | `prep`   | Diff analysis → safety check → changelog → cut RC pre-release → dispatch connector tests                                                                                                     | ~5 min  | `workflows/prep.md`                |
+| `stable`      | `finish` | Check CI + connector tests on latest RC → confirm → cut stable release                                                                                                                       | async   | `workflows/finish.md`              |
+| `status`      | —        | Show CI + connector-tests status for the latest RC, no action taken                                                                                                                          | instant | `workflows/finish.md` (bottom)     |
+| `mark-linear` | —        | **Optional manual audit** of the automated Linear release tracking — finds/labels tickets the `linear-release-tracking.yml` pipeline may have missed (needs Linear MCP). Not a release step. | varies  | `workflows/mark-linear-tickets.md` |
 
 **Dispatch rule:** When the user invokes a subcommand, **read the corresponding workflow
 file end-to-end before doing anything else**. The workflow files contain the actual
@@ -121,15 +122,16 @@ git fetch origin --tags --quiet
 
 ## Repo layout
 
-| Path                               | Purpose                                                                                                                                      |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SKILL.md`                         | This file — router and cross-cutting policies                                                                                                |
-| `workflows/prep.md`                | Full `prep` workflow (Steps 0–5)                                                                                                             |
-| `workflows/finish.md`              | Full `finish` workflow (Steps 0–6 with 3.5 sub-step) plus `status` subcommand                                                                |
-| `references/safety-assessment.md`  | 5-category structured checklist used in `prep` Step 2b                                                                                       |
-| `references/cut-release-render.md` | Markdown rendering template for `cut-release.sh` output (dry-run + real-run)                                                                 |
-| `templates/release-info-header.md` | Required prepend for every release-notes file                                                                                                |
-| `scripts/*.sh`                     | Helper scripts (next-version, cut-release, compare-upstream, check-ci, safe-fetch-tags, dispatch-connector-tests, check-connector-tests)     |
-| `notes/`                           | Generated release notes (gitignored, persists between runs). No runtime state — GitHub is the source of truth for connector-test run status. |
-| `known-flaky-tests.md`             | CI failures that don't block releases                                                                                                        |
-| `README.md`                        | Human-facing docs and validation reference                                                                                                   |
+| Path                               | Purpose                                                                                                                                                                                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SKILL.md`                         | This file — router and cross-cutting policies                                                                                                                                                                            |
+| `workflows/prep.md`                | Full `prep` workflow (Steps 0–5)                                                                                                                                                                                         |
+| `workflows/finish.md`              | Full `finish` workflow (Steps 0–6 with 3.5 sub-step) plus `status` subcommand                                                                                                                                            |
+| `workflows/mark-linear-tickets.md` | **Optional manual audit** of the automated `linear-release-tracking.yml` pipeline — cross-checks PR↔ticket links (attachment/comment aware) and labels any tickets the automation missed. Not part of the release flow. |
+| `references/safety-assessment.md`  | 5-category structured checklist used in `prep` Step 2b                                                                                                                                                                   |
+| `references/cut-release-render.md` | Markdown rendering template for `cut-release.sh` output (dry-run + real-run)                                                                                                                                             |
+| `templates/release-info-header.md` | Required prepend for every release-notes file                                                                                                                                                                            |
+| `scripts/*.sh`                     | Helper scripts (next-version, cut-release, compare-upstream, check-ci, safe-fetch-tags, dispatch-connector-tests, check-connector-tests)                                                                                 |
+| `notes/`                           | Generated release notes (gitignored, persists between runs). No runtime state — GitHub is the source of truth for connector-test run status.                                                                             |
+| `known-flaky-tests.md`             | CI failures that don't block releases                                                                                                                                                                                    |
+| `README.md`                        | Human-facing docs and validation reference                                                                                                                                                                               |

--- a/.agent-skills/oss-release/workflows/finish.md
+++ b/.agent-skills/oss-release/workflows/finish.md
@@ -113,8 +113,10 @@ Set up the notes path and run the stale-notes detector (same script `prep` uses)
 
 Capture the printed path as the notes file.
 
-Invoke the changelog skill with the full cumulative range.
-`connectors-accelerator:generating-datahub-changelog` is the skill name in Claude Code.
+Invoke the changelog skill with the full cumulative range. Use the **repo-canonical**
+`generating-datahub-changelog` skill (`.agent-skills/generating-datahub-changelog/SKILL.md`,
+`/generating-datahub-changelog`); fall back to the plugin's
+`connectors-accelerator:generating-datahub-changelog` only if the in-repo copy is absent.
 Pass **the range `<LAST_STABLE>..<RC_SHA>`** (use `LAST_STABLE` from the preflight summary
 and `RC_SHA` from Step 0) plus the same custom path filter the `prep` workflow uses. If
 the changelog skill is unavailable, fall back to skip-with-placeholder or user-provided
@@ -156,6 +158,19 @@ release. Note: **no `--prerelease`** for stable releases. Intentionally NOT in
 `.agent-skills/oss-release/references/cut-release-render.md`. For stable releases: omit
 `--prerelease` in the rendered commands code block; set `Pre-release` row in the
 parameters table to `false`. Everything else identical to the prep render.
+
+## Linear release tracking — automated, no step needed
+
+Linear release tracking is **fully automated** by the `.github/workflows/linear-release-tracking.yml`
+GitHub Action (Linear's native "Ingestion CLI/PyPI Releases" pipeline). It fires on the
+`release: published` event that `cut-release.sh`'s `gh release create` emits — so publishing
+the stable release automatically syncs issues, completes the Linear release, and stamps the
+CLI Release version label. **There is no manual `finish` step for this.**
+
+If you want to _verify_ the automation caught everything (its discovery keys off `ING-XXXX`
+in commit text, which OSS commits rarely carry), run the optional manual audit:
+`/oss-release mark-linear` → `.agent-skills/oss-release/workflows/mark-linear-tickets.md`.
+That is an audit/gap-filler, not part of the release flow.
 
 ---
 

--- a/.agent-skills/oss-release/workflows/mark-linear-tickets.md
+++ b/.agent-skills/oss-release/workflows/mark-linear-tickets.md
@@ -1,0 +1,212 @@
+# `mark-linear` — Optional manual AUDIT of Linear release tracking
+
+> **This is NOT part of the release flow and NOT the primary mechanism.** Linear release
+> tracking is automated by the `.github/workflows/linear-release-tracking.yml` GitHub Action
+> (Linear's native "Ingestion CLI/PyPI Releases" pipeline), which fires on the
+> `release: published` event that `cut-release.sh` emits and stamps the `CLI Release` version
+> label automatically. **Do not run this as a routine step** — only as an on-demand audit.
+
+**What this audit is for.** The automation discovers issues primarily by scanning commit text
+for `ING-XXXX` references — but OSS commits carry `#PR` numbers, not ticket IDs, so tickets
+linked only via the **PR attachment / `[PR Review]` integration** can be missed. This audit
+does a more thorough PR↔ticket discovery (PR-number search **plus** attachment/comment scan)
+and reports any tickets the automation may have skipped — optionally filling the gap by
+applying the version label to confirmed-missed tickets.
+
+It is **safe to skip**, **never required**, and Claude Code-specific (needs the **Linear MCP**,
+`mcp__claude_ai_Linear__*`). Agents without Linear access should skip it and say so.
+
+> **Why it's its own file:** opt-in, touches an external system, and duplicates an automated
+> pipeline — so it stays out of `prep.md`/`finish.md`. Read this file only when the operator
+> explicitly asks to audit Linear release tracking.
+
+---
+
+## When to run
+
+- **Only on demand**, when you want to verify the automated `linear-release-tracking.yml`
+  pipeline didn't miss any tickets for a published release — e.g. a spot-check after a release,
+  or when Support reports a fix-version that looks unset.
+- Not on every release. The GitHub Action already handles the routine case.
+
+## Prerequisites
+
+- Linear MCP connected (`mcp__claude_ai_Linear__list_issues` available).
+- The release tag exists and you know its version and comparison range (same range the
+  changelog used — see `scripts/release-range-diff.sh`).
+
+---
+
+## Step 1 — Resolve the version label
+
+The label is the **CLI Release** child matching the shipped version, e.g. `v1.5.0.20`
+(4-segment patch). Confirm it exists:
+
+```
+mcp__claude_ai_Linear__list_issue_labels  name="<VERSION>"   # e.g. v1.5.0.20
+```
+
+Expect one label whose `parent` is `CLI Release` (description `Released in <VERSION>`).
+
+> ⚠️ **`.0` minor releases have no CLI Release label.** The CLI Release family is 4-segment
+> patches only (`v1.6.0.1`, `v1.5.0.20`). A bare minor like `v1.6.0` exists only as an
+> _ungrouped_ label (and minors live under **OSS Release**, not CLI Release). If you are
+> marking a `.0` minor, **stop and ask the operator** which label to apply: the ungrouped
+> `vX.Y.0`, a new CLI Release child, or skip. Do not guess.
+
+## Step 2 — Collect the PRs in the release range
+
+**Do not hand-roll the range.** Use the _same_ comparison base the changelog/release used —
+the previous **stable** tag (`get_comparison_version` logic), not an arbitrary `git log`
+base. The release skill already computes this:
+
+```bash
+.agent-skills/oss-release/scripts/release-range-diff.sh   # commits/files since latest stable
+```
+
+- If you are running this right after `prep`/`stable`, **reuse the range that workflow already
+  resolved** (`LAST_STABLE..RC_SHA`) — it is the same set the changelog was generated from, so
+  the tickets you stamp line up exactly with the notes you shipped.
+- The changelog skill is the source of truth for "what PRs are in this release." If a
+  categorized PR list was already produced for the notes, take the PR numbers from there.
+
+Then extract the PR numbers (add the ingestion path filter only if you want ingestion tickets):
+
+```bash
+git log <BASE>..<TAG> --pretty=format:'%s' \
+  [-- metadata-ingestion/ metadata-ingestion-modules/] \
+  | grep -oE '#[0-9]+' | tr -d '#' | sort -u
+```
+
+where `<BASE>` is the previous-stable tag from the step above — never a guessed base. This
+keeps mark-linear's ticket set consistent with the changelog (see the comparison-base rule:
+minor `.0` releases compare against the previous _stable_ patch, e.g. `v1.6.0` ← `v1.5.0.19`).
+
+## Step 3 — Find the linked Linear tickets (THREE directions — all needed)
+
+Linear's `list_issues` `query` searches **title + description only**. That alone misses PRs
+linked through a ticket's **attachment** (the GitHub integration's primary link) or a **comment**.
+Run all three directions and union the results. **You must check attachments and comments, not
+just title/description.**
+
+**A) Linear text-search (per PR)** — finds the auto-created `[PR Review]` tickets:
+
+```
+mcp__claude_ai_Linear__list_issues  query="<PR_NUMBER>"  limit=5
+```
+
+Keep a result **only if** its title or description literally contains `#<PR_NUMBER>` or
+`/pull/<PR_NUMBER>`. Discard topical-but-unreferenced matches.
+
+**B) PR-side scan (per PR)** — catches tickets the PR itself names (branch `feature/ing-1234`,
+title/body `(ING-1234)`, "Refs: CUS-…"):
+
+```bash
+gh pr view <PR_NUMBER> --repo datahub-project/datahub --json title,body,headRefName,comments
+# extract refs matching (case-insensitive): (ING|OSS|CUS|PLAT|PFP|CAT|OBS|ACR|SE)-[0-9]+
+```
+
+**C) Linear attachment + comment scan (per candidate ticket)** — the part title/description
+search cannot do. For every ticket surfaced by A or B, read its attachments and comments and
+confirm/expand the PR link:
+
+```
+mcp__claude_ai_Linear__get_issue       id="<TICKET>"      # returns attachments[] (each has .url)
+mcp__claude_ai_Linear__list_comments   issueId="<TICKET>" # discussion + inline comments
+```
+
+- In `attachments[].url` and each comment `body`, look for `github.com/.../pull/<N>` and
+  `(ING|OSS|CUS|…)-\d+` refs. The PR **attachment** is the authoritative GitHub-integration
+  signal — a ticket can carry the PR as an attachment with **no** mention in its description.
+- This both **confirms** an A/B match (attachment url == the PR) and **finds sibling PRs**
+  attached to the same ticket.
+- Keep a ticket as a match for `<PR>` if its attachment url or a comment references that PR.
+
+> **Discovery limit (be honest about it):** there is **no global Linear search by attachment
+> url or comment text**. Direction C can only run over tickets you already have a handle on
+> (from A/B). A ticket whose _only_ link to a release PR is an attachment — with no text match
+> and no PR-side reference — is not discoverable with the current MCP tools. If thorough
+> coverage matters, widen the candidate set before running C: e.g. `list_issues team="Ingestion Pod"
+label="oss-pr-review"` and recently-updated customer tickets, then scan each one's attachments
+> for the release's PR numbers.
+
+For large ranges, dispatch a sub-agent to run A+B+C across all PRs/candidates and return a
+compact `PR | ticket | status | customer | link source (A/B/C)` table — keeps the main context clean.
+
+## Step 4 — Decide scope (which tickets get the label)
+
+| Ticket kind                                                  | Label it?                                 |
+| ------------------------------------------------------------ | ----------------------------------------- |
+| `[PR Review]` ticket (`oss-pr-review`) for a shipped PR      | **Yes**                                   |
+| **Non-closed** customer/feature ticket fixed by this release | **Yes** (so Support sees the fix version) |
+| **Closed** customer ticket                                   | No, unless the operator asks              |
+| `PFP-*` / `OBS-*` / `CAT-*` merge-conflict sign-off tickets  | No, unless the operator asks              |
+
+Default selection rule: **non-closed tickets where the CLI Release label is not already set**,
+plus the per-PR `[PR Review]` tickets.
+
+## Step 5 — Build the update plan (read-only) and SHOW it
+
+> ⚠️ **Never overwrite an existing CLI Release version.** If a ticket already carries **any**
+> concrete CLI Release version label (a `vX.Y.Z.W` under the `CLI Release` parent — not the
+> pending `CLI Next`), **leave it untouched and skip it**, even if that version differs from
+> the one you're stamping. A fix can first ship in an earlier CLI build; the _first_ shipped
+> version is the one worth recording, so do not clobber or stack a second version label.
+
+First, **read only** — make NO writes yet. For each selected ticket, `get_issue` to read its
+current `labels`, then classify it:
+
+- **will-update**: has `CLI Next` or no CLI Release label → would be stamped `<VERSION>`.
+- **skip (already versioned)**: already has a concrete `CLI Release` version → leave untouched.
+
+Then present the plan as a table and **stop** — this is the mandatory gate before any mass
+update. Required columns:
+
+| Ticket   | Title          | PR(s)  | Current CLI label | → New version | Action                   |
+| -------- | -------------- | ------ | ----------------- | ------------- | ------------------------ |
+| ING-1234 | <ticket title> | #17527 | `CLI Next`        | `<VERSION>`   | will update              |
+| ING-5678 | <ticket title> | #17440 | _none_            | `<VERSION>`   | will update              |
+| ING-9012 | <ticket title> | #16842 | `v1.5.0.18`       | —             | skip (already versioned) |
+
+Below the table, state the counts: **N tickets will be updated, M skipped**. Separately list
+the skipped-already-versioned tickets (with their existing version) so the operator can spot
+fixes that shipped in an earlier build.
+
+## Step 6 — Confirmation gate, then apply
+
+> ⚠️ **`save_issue` `labels` REPLACES the entire label set** (it is NOT append-only, unlike
+> `links`). You MUST resubmit the full intended set from the ticket's current labels.
+
+**This is a bulk write to an external system — always gate it:**
+
+| Mode         | Behavior                                                                                                                                                                                                                           |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Real run** | After showing the Step 5 plan table, **wait for the operator to explicitly type "yes" / "confirm"** before a single `save_issue`. Silence is not consent. If they want only a subset, take their edited list and re-show the plan. |
+| **Dry-run**  | Show the plan table, announce "In a real run I would pause here for confirmation and then apply these," and make **no** `save_issue` calls.                                                                                        |
+
+Once confirmed, apply to each **will-update** ticket:
+
+1. New label set = current labels **minus** `CLI Next` **plus** `<VERSION>` (dedup; never drop
+   any other label — preserve `oss-pr-review`, `Source:*`, `Company:*`, `OSS-Next`, `SaaS-Next`, etc.).
+2. `mcp__claude_ai_Linear__save_issue id="<TICKET>" labels=[<full new set, by name>]`.
+
+Pass version labels by exact name; 4-segment version names are unique in the workspace. Re-running
+the whole step is idempotent — already-versioned tickets are classified "skip" in Step 5.
+
+## Step 7 — Report
+
+Output a compact results table: `Ticket | Action (set <VERSION> [removed CLI Next] / already set: <existing version> / skipped) | Final CLI label | link source (A/B/C)`, then a short list of any
+customer tickets touched. Note any ticket the operator excluded from the plan.
+
+---
+
+## Notes & gotchas
+
+- **No CLI Release label for `.0` minors** — see Step 1 warning.
+- **A ticket can reference a PR that never merged** (attachment to a closed/open PR). The
+  changelog only contains _merged_ commits, so a PR in a ticket's attachment may not be in any
+  release range — don't label off attachments alone; label off the in-range PR set from Step 2.
+- **Three release label families** (each with a `…-Next` pending label): `CLI Release`
+  (4-segment CLI patches), `OSS Release` (core/GMS minors like `v1.5.0`), `SaaS Release`
+  (`-acryl` / `-cloud`). This step only touches **CLI Release**; leave `OSS-Next` / `SaaS-Next`
+  for their respective owners unless asked.

--- a/.agent-skills/oss-release/workflows/prep.md
+++ b/.agent-skills/oss-release/workflows/prep.md
@@ -171,9 +171,12 @@ target when the changelog skill produces content.
 
 **Default path — generate via the changelog skill:**
 
-Check if the `generating-datahub-changelog` skill is available in your runtime's skill registry
-(in Claude Code, look for `connectors-accelerator:generating-datahub-changelog` in the
-available-skills list).
+Use the **repo-canonical** changelog skill at
+`.agent-skills/generating-datahub-changelog/SKILL.md` (invokable as the
+`generating-datahub-changelog` skill / `/generating-datahub-changelog` command). It is
+vendored into this repo and version-controlled — **prefer it over** the plugin's
+`connectors-accelerator:generating-datahub-changelog`, which is only a fallback for repos
+that don't have the in-repo copy.
 
 If available, invoke it via your native skill tool (e.g. Claude Code's `Skill` tool). **Your
 first action inside the invoked skill MUST be to `Read` the template file that matches the

--- a/.claude/commands/generating-datahub-changelog.md
+++ b/.claude/commands/generating-datahub-changelog.md
@@ -1,0 +1,40 @@
+---
+description: Generate a changelog / release notes for a DataHub release range (repo-canonical, vendored from the connectors-accelerator plugin)
+argument-hint: '[daily|weekly|"last 2 weeks"|prs:...|from:tag] [ingestion|backend|frontend|all] [internal|external]'
+allowed-tools:
+  # GitHub CLI - read-only repo queries
+  - Bash(gh pr view:*)
+  - Bash(gh pr list:*)
+  - Bash(gh api:*)
+  # Git - read-only log/tag queries
+  - Bash(git log:*)
+  - Bash(git tag:*)
+  # Utilities - safe read-only operations
+  - Bash(date:*)
+  - Bash(curl:*)
+  - Bash(jq:*)
+  # Vendored python scripts
+  - Bash(python3 .agent-skills/generating-datahub-changelog/scripts/extract_linear_refs.py:*)
+  - Bash(python3 .agent-skills/generating-datahub-changelog/scripts/extract_customers.py:*)
+  - Bash(python3 .agent-skills/generating-datahub-changelog/scripts/calculate_merge_stats.py:*)
+  # File tools
+  - Read
+  - Grep
+  - Glob
+  - Write
+  # Linear API - read-only (changelog enrichment, internal mode)
+  - mcp__claude_ai_Linear__list_issues
+  - mcp__claude_ai_Linear__get_issue
+---
+
+# Generate DataHub Changelog
+
+**User's request:** $ARGUMENTS
+
+**Read `.agent-skills/generating-datahub-changelog/SKILL.md` and follow it exactly.** That file
+is the repo-canonical, version-controlled copy of the changelog workflow (vendored from the
+`connectors-accelerator` plugin). Its script, template, and reference paths are repo-relative
+under `.agent-skills/generating-datahub-changelog/`.
+
+Prefer this in-repo skill over the plugin's `connectors-accelerator:generating-datahub-changelog`
+when working inside this repository.

--- a/.claude/commands/oss-release.md
+++ b/.claude/commands/oss-release.md
@@ -1,6 +1,6 @@
 ---
-description: Cut an RC or stable release of the acryl-datahub OSS CLI, or check its status
-argument-hint: [rc|stable|status] [patch|minor|major|fourth] [--dry-run]
+description: Cut an RC or stable release of the acryl-datahub OSS CLI, check its status, or mark Linear tickets with the shipped version
+argument-hint: [rc|stable|status|mark-linear] [patch|minor|major|fourth] [--dry-run]
 allowed-tools: Bash(.agent-skills/oss-release/scripts/preflight.sh:*), Bash(.agent-skills/oss-release/scripts/finish-preflight.sh:*), Bash(.agent-skills/oss-release/scripts/safe-fetch-tags.sh:*), Bash(.agent-skills/oss-release/scripts/next-version.sh:*), Bash(.agent-skills/oss-release/scripts/compare-upstream.sh:*), Bash(.agent-skills/oss-release/scripts/release-range-diff.sh:*), Bash(.agent-skills/oss-release/scripts/prepare-notes.sh:*), Bash(.agent-skills/oss-release/scripts/fetch-rc-notes.sh:*), Bash(.agent-skills/oss-release/scripts/check-ci.sh:*), Bash(.agent-skills/oss-release/scripts/check-connector-tests.sh:*), Bash(.agent-skills/oss-release/scripts/wait-for-pypi-release.sh:*), Bash(.agent-skills/oss-release/scripts/validate-rc-for-promotion.sh:*), Bash(.agent-skills/oss-release/scripts/status.sh:*), Bash(.agent-skills/oss-release/tests/run-all.sh:*)
 ---
 
@@ -25,5 +25,13 @@ Run the OSS CLI release workflow for acryldata/datahub.
   confirmation, then cuts the final tag.
 
 - **`status`** — Check CI status (release + connector tests) for the latest RC without taking action.
+
+- **`mark-linear`** (optional manual **audit** — not a release step) — Linear release tracking is
+  already automated by `.github/workflows/linear-release-tracking.yml` (fires on `release: published`).
+  Use this only to **verify that automation didn't miss tickets**: it does a more thorough PR↔ticket
+  discovery (PR-number + attachment/comment scan) and can label confirmed-missed tickets. Requires the
+  Linear MCP — if unavailable, say so and skip. Read
+  `.agent-skills/oss-release/workflows/mark-linear-tickets.md` and follow it. Append `--dry-run` to
+  preview without writing.
 
 If no subcommand is given, ask the user which they want.


### PR DESCRIPTION
## Summary

Vendors the `generating-datahub-changelog` skill into the repo and reworks the `oss-release` skill so release tooling is version-controlled and independent of the `connectors-accelerator` plugin cache.

## What changed

- **Vendored changelog skill** → `.agent-skills/generating-datahub-changelog/` (SKILL.md, scripts, templates, references) with repo-relative paths, plus a `/generating-datahub-changelog` command entry. Example company names in templates/scripts are **fictional placeholders** (Acme, Globex, Initech, Contoso, Hooli; `*.example` domains) — no real customer names in this public repo.
- **oss-release rewiring** — `prep`/`finish` now prefer the in-repo changelog skill, falling back to the plugin only when absent.
- **`mark-linear` = optional manual AUDIT** (`workflows/mark-linear-tickets.md`, `/oss-release mark-linear`), **not** a release step. Linear release tracking is already automated by `.github/workflows/linear-release-tracking.yml`; this audit cross-checks PR↔ticket links (PR-number + attachment/comment scan), never overwrites an existing CLI Release version, and requires a plan + confirmation gate before any bulk Linear write.

## Testing

- `/oss-release rc --dry-run` validated end-to-end in an isolated worktree: preflight, upstream diff, range diff, version calc, changelog via the vendored skill, and `cut-release.sh --dry-run` (no tag/release created).
- Vendored scripts run from repo-relative paths; markdown passes the prettier pre-commit hook.

## Notes

Tooling-only change (`.agent-skills/`, `.claude/`) — no product/runtime code, no breaking changes, no `docs/` updates needed.

### Checklist
- [x] PR title follows the format (`feat(scope): ...`)
- [ ] Links to related issues (n/a — internal release tooling)
- [x] Validation added (dry-run end-to-end)
- [x] Docs (self-documenting skill files)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)