### PR TITLE
fix(ci): repair Linear release tracking commit scan and PR lookup

### DIFF
--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -249,24 +249,62 @@ jobs:
           fi
           echo "PRs in this release: $(echo "$PR_NUMBERS" | tr '\n' ' ')"
 
-          # 4. Build a set of Linear issue identifiers whose PRs are in this release,
-          #    by reading the "Linear: XXX-NNNN" comment that pr-to-linear.yml posts.
-          #    Accept any team prefix — we track ingestion-path changes regardless of which
-          #    team owns the Linear ticket.
+          # 4. Build a set of Linear issue identifiers whose PRs are in this release. Accept
+          #    any team prefix — ingestion-path changes are tracked regardless of which team
+          #    owns the ticket.
+          #
           #    Look the PRs up UPSTREAM: this repo is a fork, and the "(#NNNNN)" numbers in
           #    commit subjects are datahub-project/datahub PR numbers. The fork has its own,
           #    much lower, PR numbering, so querying it here resolved nothing — every lookup
           #    404'd into the `// ""` fallback and the step reported "No Linear issues resolved".
+          #
+          #    Three directions, unioned. Measured over the 25 PRs in v1.7.0.2: (a) alone
+          #    resolved 2, adding (b) resolved 8. (c) resolved 0 there — this workspace's
+          #    [PR Review] tickets carry the PR in their description rather than as an
+          #    attachment — but it is the only direction that finds a ticket someone attached
+          #    a PR to by hand, which is the case Support cares about.
+          PREFIXES='(ING|OSS|CUS|PLAT|PFP|CAT|OBS|ACR|SE)'
           ISSUES_IN_RELEASE=""
           for PR in $PR_NUMBERS; do
-            IDENTIFIER=$(gh pr view "$PR" \
-              --repo datahub-project/datahub \
-              --json comments \
-              --jq '[.comments[].body | match("Linear: ([A-Z]+-[0-9]+)") | .captures[0].string] | first // ""' 2>/dev/null)
-            if [ -n "$IDENTIFIER" ]; then
-              ISSUES_IN_RELEASE="$ISSUES_IN_RELEASE $IDENTIFIER"
-            fi
+            # (a) the "Linear: XXX-NNNN" comment pr-to-linear.yml posts. Restricted to that
+            #     exact prefix: a bare identifier in a comment is usually a reviewer
+            #     referencing some other ticket, not a link to this PR's work.
+            CANDIDATES=$(gh pr view "$PR" --repo datahub-project/datahub --json comments \
+              --jq '[.comments[]?.body // ""] | join("\n")' 2>/dev/null \
+              | grep -oE "Linear: ${PREFIXES}-[0-9]+" | sed 's/^Linear: //')
+
+            # (b) identifiers in the branch name or title. Branch names are the largest
+            #     single source (Linear's copy-git-branch convention) and are conventionally
+            #     lowercase, so match case-insensitively and normalise below.
+            #
+            #     The body is deliberately NOT searched: it routinely mentions adjacent
+            #     tickets ("part 1 of the X work (CAT-2789 / CAT-2783)") that are not what
+            #     this PR shipped, and in testing it surfaced no identifier the branch name
+            #     did not already give. \b matters too — without it "phase-1" matches the
+            #     SE prefix and yields a bogus SE-1.
+            CANDIDATES="${CANDIDATES}
+          $(gh pr view "$PR" --repo datahub-project/datahub --json headRefName,title \
+              --jq '[.headRefName, .title] | join("\n")' 2>/dev/null \
+              | grep -oiE "\b${PREFIXES}-[0-9]+")"
+
+            # (c) tickets carrying this PR as an attachment — the reverse lookup, which is
+            #     the only way to find a link that exists solely on the Linear side.
+            CANDIDATES="${CANDIDATES}
+          $(curl -s -X POST https://api.linear.app/graphql \
+              -H "Authorization: $LINEAR_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "{\"query\": \"{ attachmentsForURL(url: \\\"https://github.com/datahub-project/datahub/pull/${PR}\\\") { nodes { issue { identifier } } } }\"}" \
+              | jq -r '.data.attachmentsForURL.nodes[]?.issue.identifier // empty')"
+
+            for ID in $(printf '%s\n' "$CANDIDATES" | tr '[:lower:]' '[:upper:]' \
+                        | grep -E "^${PREFIXES}-[0-9]+$" | sort -u); do
+              ISSUES_IN_RELEASE="$ISSUES_IN_RELEASE $ID"
+            done
           done
+
+          # Several PRs commonly share one ticket, so dedup before attaching.
+          # shellcheck disable=SC2086
+          ISSUES_IN_RELEASE=$(printf '%s\n' $ISSUES_IN_RELEASE | sort -u | tr '\n' ' ')
 
           if [ -z "$ISSUES_IN_RELEASE" ]; then
             echo "No Linear issues resolved from PRs in this range"

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -71,10 +71,26 @@ on:
           "testing_release" works.
         required: false
         type: string
+      base_ref:
+        description: >
+          Only for backfills with sync. Exclusive scan base — the action scans
+          <base_ref>..HEAD. Leave empty for normal runs, where the base is derived from the
+          most recent release's commitSha. Set it when that base is stale (e.g. after a
+          period where no release was recorded), otherwise sync attributes every commit
+          since that stale base to the release being backfilled. Pass the previous stable
+          tag, e.g. v1.7.0 when backfilling v1.7.0.2.
+        required: false
+        type: string
 
 env:
   CLI_NEXT_RELEASE_ID: "7de48387-0024-4156-9c60-33a237985f65"
   LINEAR_PIPELINE_ID: "1dded0ef-0a6a-421a-805b-2761579688b4"
+  # Repo-relative globs, matching this workflow's own push/PR path filters. Set explicitly
+  # because the pipeline-side default was owner/repo-qualified
+  # ("acryldata/datahub/metadata-ingestion/**"), which matches no commit path — every sync
+  # then logged "Found 0 matching commits" and skipped release creation, so the follow-up
+  # `complete` failed with "No release found with version <v>".
+  INCLUDE_PATHS: "metadata-ingestion/**,docs/**"
 
 jobs:
   # ── JOB 1: PR MERGED → add associated Linear issue to cli-next ──────────────
@@ -144,6 +160,7 @@ jobs:
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          include_paths: ${{ env.INCLUDE_PATHS }}
 
       # ── 2. ANY RELEASE PUBLISHED ─────────────────────────────────────────
       - name: Extract version from GitHub release tag
@@ -157,6 +174,7 @@ jobs:
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           version: ${{ env.RELEASE_VERSION }}
+          include_paths: ${{ env.INCLUDE_PATHS }}
 
       - name: Advance to Testing Release stage on RC
         if: github.event_name == 'release' && contains(github.event.release.tag_name, 'rc')
@@ -174,6 +192,7 @@ jobs:
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           version: ${{ env.RELEASE_VERSION }}
+          include_paths: ${{ env.INCLUDE_PATHS }}
 
       - name: Complete release + generate release notes
         if: github.event_name == 'release' && !contains(github.event.release.tag_name, 'rc')
@@ -233,10 +252,14 @@ jobs:
           #    by reading the "Linear: XXX-NNNN" comment that pr-to-linear.yml posts.
           #    Accept any team prefix — we track ingestion-path changes regardless of which
           #    team owns the Linear ticket.
+          #    Look the PRs up UPSTREAM: this repo is a fork, and the "(#NNNNN)" numbers in
+          #    commit subjects are datahub-project/datahub PR numbers. The fork has its own,
+          #    much lower, PR numbering, so querying it here resolved nothing — every lookup
+          #    404'd into the `// ""` fallback and the step reported "No Linear issues resolved".
           ISSUES_IN_RELEASE=""
           for PR in $PR_NUMBERS; do
             IDENTIFIER=$(gh pr view "$PR" \
-              --repo acryldata/datahub \
+              --repo datahub-project/datahub \
               --json comments \
               --jq '[.comments[].body | match("Linear: ([A-Z]+-[0-9]+)") | .captures[0].string] | first // ""' 2>/dev/null)
             if [ -n "$IDENTIFIER" ]; then
@@ -285,6 +308,8 @@ jobs:
           command: ${{ inputs.command }}
           stage: ${{ inputs.stage }}
           version: ${{ inputs.version }}
+          include_paths: ${{ env.INCLUDE_PATHS }}
+          base_ref: ${{ inputs.base_ref }}
 
   # ── JOB 3: RELEASE DELETED IN GITHUB → delete corresponding Linear release ─
   delete-linear-release:

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -202,8 +202,9 @@ jobs:
           command: complete
           version: ${{ env.RELEASE_VERSION }}
 
-      # Both RC and stable: migrate cli-next issues that are confirmed in this release's commit range
-      - name: Migrate issues from cli-next to versioned release
+      # Both RC and stable: attach the issues whose PRs are in this release's commit range,
+      # and de-stage any of them that were sitting in cli-next
+      - name: Attach release issues and clear them from cli-next
         if: github.event_name == 'release'
         env:
           LINEAR_API_KEY: ${{ secrets.INGESTION_LINEAR_KEY }}
@@ -273,29 +274,48 @@ jobs:
           fi
           echo "Linear issues confirmed in this release:$ISSUES_IN_RELEASE"
 
-          # 5. Get all issues currently in cli-next
-          CLI_NEXT_ISSUES=$(curl -s -X POST https://api.linear.app/graphql \
+          # 5. Snapshot which of those issues are currently staged in cli-next, so they can be
+          #    de-staged after being attached. Membership is looked up per identifier below.
+          CLI_NEXT_IDENTIFIERS=$(curl -s -X POST https://api.linear.app/graphql \
             -H "Authorization: $LINEAR_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{\"query\": \"{ release(id: \\\"$CLI_NEXT_RELEASE_ID\\\") { issues { nodes { id identifier } } } }\"}" \
-            | jq -r '.data.release.issues.nodes[] | .id + " " + .identifier')
+            -d "{\"query\": \"{ release(id: \\\"$CLI_NEXT_RELEASE_ID\\\") { issues { nodes { identifier } } } }\"}" \
+            | jq -r '.data.release.issues.nodes[].identifier')
 
-          # 6. Migrate only issues that are both in cli-next AND confirmed in this release
-          echo "$CLI_NEXT_ISSUES" | while read -r UUID IDENTIFIER; do
-            if echo "$ISSUES_IN_RELEASE" | grep -qw "$IDENTIFIER"; then
-              echo "  Migrating $IDENTIFIER..."
-              curl -s -X POST https://api.linear.app/graphql \
-                -H "Authorization: $LINEAR_API_KEY" \
-                -H "Content-Type: application/json" \
-                -d "{\"query\": \"mutation { issueToReleaseCreate(input: { releaseId: \\\"$RELEASE_ID\\\", issueId: \\\"$UUID\\\" }) { success } }\"}" \
-                | jq -r '"    add to versioned: " + (.data.issueToReleaseCreate.success | tostring)'
+          # 6. Attach every confirmed issue to the versioned release, then de-stage the ones
+          #    that were in cli-next.
+          #
+          #    This used to iterate cli-next and attach only issues found in BOTH sets. That
+          #    intersection is empty whenever cli-next is — which is the steady state here,
+          #    since add-to-cli-next fires on pull_request_target in this fork and the fork
+          #    mostly receives upstream sync-merges rather than individual PRs. The release's
+          #    own commit range is the authoritative membership signal, so drive off that and
+          #    treat cli-next purely as a staging area to clean up.
+          for IDENTIFIER in $ISSUES_IN_RELEASE; do
+            UUID=$(curl -s -X POST https://api.linear.app/graphql \
+              -H "Authorization: $LINEAR_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "{\"query\": \"{ issue(id: \\\"$IDENTIFIER\\\") { id } }\"}" \
+              | jq -r '.data.issue.id // empty')
+
+            if [ -z "$UUID" ]; then
+              echo "  Could not resolve $IDENTIFIER to a Linear issue — skipping"
+              continue
+            fi
+
+            echo "  Attaching $IDENTIFIER..."
+            curl -s -X POST https://api.linear.app/graphql \
+              -H "Authorization: $LINEAR_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "{\"query\": \"mutation { issueToReleaseCreate(input: { releaseId: \\\"$RELEASE_ID\\\", issueId: \\\"$UUID\\\" }) { success } }\"}" \
+              | jq -r '"    add to versioned: " + (.data.issueToReleaseCreate.success | tostring)'
+
+            if echo "$CLI_NEXT_IDENTIFIERS" | grep -qw "$IDENTIFIER"; then
               curl -s -X POST https://api.linear.app/graphql \
                 -H "Authorization: $LINEAR_API_KEY" \
                 -H "Content-Type: application/json" \
                 -d "{\"query\": \"mutation { issueToReleaseDeleteByIssueAndRelease(issueId: \\\"$UUID\\\", releaseId: \\\"$CLI_NEXT_RELEASE_ID\\\") { success } }\"}" \
                 | jq -r '"    remove from cli-next: " + (.data.issueToReleaseDeleteByIssueAndRelease.success | tostring)'
-            else
-              echo "  Skipping $IDENTIFIER — not confirmed in $TAG commit range"
             fi
           done
 

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -95,13 +95,13 @@ env:
   # `release: published` event publishes acryl-datahub-actions and the
   # airflow/dagster/gx/prefect plugins too.
   #
-  # Top-level docs/ is NOT a code path here. Taking every commit that touches it sweeps in
-  # backend and SaaS work that happened to update documentation — on v1.7.0.2 that was
-  # perf(gms) batch-form performance, feat(assertions) model changes and feat(data products)
-  # hierarchies, none of which ship in these packages. Documentation PRs proper are still
-  # tracked, via the docs-subject rule in step 3 below.
-  # Connector documentation is unaffected either way: it lives under
-  # metadata-ingestion/docs/sources/, inside a code path.
+  # Top-level docs/ is excluded. This pipeline tracks what ships in these packages, and a
+  # change confined to docs/ ships in none of them. Including it also swept in backend and
+  # SaaS work that merely updated documentation — on v1.7.0.2 that was perf(gms) batch-form
+  # performance, feat(assertions) model changes and feat(data products) hierarchies, the last
+  # of which pulled a Catalog ticket into an ingestion release.
+  # Connector documentation is unaffected: it lives under metadata-ingestion/docs/sources/,
+  # inside a code path.
   # Keep in sync with RELEASE_PATHSPECS below.
   INCLUDE_PATHS: "metadata-ingestion/**,metadata-ingestion-modules/**,datahub-actions/**"
   # Same scope as INCLUDE_PATHS, in git pathspec form for `git log`.
@@ -263,28 +263,17 @@ jobs:
           fi
           echo "Commit range: $PREV_TAG..$TAG"
 
-          # 3. Extract PR numbers from commits in this release's range. Two sources, unioned.
-          #
-          #    (i)  any commit touching a shipping code path. Without a pathspec the range
-          #         also yields GMS, GraphQL and web-react PRs that ship in none of these
-          #         packages and do not belong in this pipeline.
-          #
-          #    (ii) commits under docs/ whose subject carries a docs prefix. A `docs(...)` or
-          #         `docs:` subject marks a genuine documentation change, which is part of the
-          #         release. A backend PR that merely edited documentation keeps its own
-          #         prefix — perf(gms), feat(assertions), feat(data products) — and is
-          #         correctly left out. The subject prefix is what separates the two; the path
-          #         alone cannot.
+          # 3. Extract PR numbers from commits in this release's range, scoped to the paths
+          #    that actually ship. Without the pathspec the range also yields GMS, GraphQL and
+          #    web-react PRs, plus backend work that only touched docs/ — none of which ship
+          #    in these packages or belong in this pipeline.
           #
           #    Requiring the parentheses matches the "(#NNNNN)" squash-merge suffix rather
           #    than any PR mentioned mid-subject (e.g. "revert #18000 (#18955)").
           # shellcheck disable=SC2086
-          CODE_PRS=$(git log "$PREV_TAG".."$TAG" --format="%s" --no-merges -- $RELEASE_PATHSPECS \
-            | grep -oE '\(#[0-9]+\)' | tr -d '(#)')
-          DOCS_PRS=$(git log "$PREV_TAG".."$TAG" --format="%s" --no-merges -- docs/ \
-            | grep -E '^docs[(:]' \
-            | grep -oE '\(#[0-9]+\)' | tr -d '(#)')
-          PR_NUMBERS=$(printf '%s\n%s\n' "$CODE_PRS" "$DOCS_PRS" | grep . | sort -u)
+          PR_NUMBERS=$(git log "$PREV_TAG".."$TAG" --format="%s" --no-merges -- $RELEASE_PATHSPECS \
+            | grep -oE '\(#[0-9]+\)' \
+            | tr -d '(#)' | sort -u)
 
           if [ -z "$PR_NUMBERS" ]; then
             echo "No PRs found in range $PREV_TAG..$TAG"

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -300,6 +300,26 @@ jobs:
           done
 
       # ── 3. MANUAL DISPATCH ────────────────────────────────────────────────
+
+      # The action takes the release's commit from HEAD — it has no input for it. On a
+      # `release` event HEAD is already the tagged commit, but a dispatch checks out the ref
+      # it was launched from, so a backfill run from a branch stamps the release with that
+      # branch's tip. That SHA is what later runs use as their scan baseline, so a wrong
+      # value silently mis-scopes every subsequent sync (and breaks outright if the branch
+      # is later deleted). Pin HEAD to the tag so the stored SHA is right regardless of the
+      # ref the backfill was dispatched from.
+      - name: Check out the tag being backfilled
+        if: github.event_name == 'workflow_dispatch' && inputs.version != ''
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+            echo "::error::Tag ${VERSION} not found. Pass a version matching an existing release tag."
+            exit 1
+          fi
+          git checkout --detach "refs/tags/${VERSION}"
+          echo "HEAD is now $(git rev-parse HEAD) (${VERSION})"
+
       - name: Manual release command
         if: github.event_name == 'workflow_dispatch'
         uses: linear/linear-release-action@v0

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -90,14 +90,22 @@ env:
   # path — every sync then logged "Found 0 matching commits" and skipped release creation, so
   # the follow-up `complete` failed with "No release found with version <v>".
   #
-  # Scope matches the oss-release changelog filter, i.e. what the release actually ships to
-  # PyPI: the CLI plus the sibling plugin packages. metadata-ingestion-modules/ and
-  # datahub-actions/ are included for that reason — a `release: published` event publishes
-  # acryl-datahub-actions and the airflow/dagster/gx/prefect plugins too.
+  # Scope is what the release actually ships to PyPI: the CLI plus the sibling plugin
+  # packages. metadata-ingestion-modules/ and datahub-actions/ are included because a
+  # `release: published` event publishes acryl-datahub-actions and the
+  # airflow/dagster/gx/prefect plugins too.
+  #
+  # Top-level docs/ is NOT a code path here. Taking every commit that touches it sweeps in
+  # backend and SaaS work that happened to update documentation — on v1.7.0.2 that was
+  # perf(gms) batch-form performance, feat(assertions) model changes and feat(data products)
+  # hierarchies, none of which ship in these packages. Documentation PRs proper are still
+  # tracked, via the docs-subject rule in step 3 below.
+  # Connector documentation is unaffected either way: it lives under
+  # metadata-ingestion/docs/sources/, inside a code path.
   # Keep in sync with RELEASE_PATHSPECS below.
-  INCLUDE_PATHS: "metadata-ingestion/**,metadata-ingestion-modules/**,datahub-actions/**,docs/**"
+  INCLUDE_PATHS: "metadata-ingestion/**,metadata-ingestion-modules/**,datahub-actions/**"
   # Same scope as INCLUDE_PATHS, in git pathspec form for `git log`.
-  RELEASE_PATHSPECS: "metadata-ingestion/ metadata-ingestion-modules/ datahub-actions/ docs/"
+  RELEASE_PATHSPECS: "metadata-ingestion/ metadata-ingestion-modules/ datahub-actions/"
 
 jobs:
   # ── JOB 1: PR MERGED → add associated Linear issue to cli-next ──────────────
@@ -255,15 +263,28 @@ jobs:
           fi
           echo "Commit range: $PREV_TAG..$TAG"
 
-          # 3. Extract PR numbers from commits in this release's range, scoped to the paths
-          #    that actually ship. Without the pathspec the range also yields GMS, GraphQL and
-          #    web-react PRs, which do not ship in these packages and do not belong in this
-          #    pipeline. Requiring the parentheses matches the "(#NNNNN)" squash-merge suffix
-          #    rather than any PR mentioned mid-subject (e.g. "revert #18000 (#18955)").
+          # 3. Extract PR numbers from commits in this release's range. Two sources, unioned.
+          #
+          #    (i)  any commit touching a shipping code path. Without a pathspec the range
+          #         also yields GMS, GraphQL and web-react PRs that ship in none of these
+          #         packages and do not belong in this pipeline.
+          #
+          #    (ii) commits under docs/ whose subject carries a docs prefix. A `docs(...)` or
+          #         `docs:` subject marks a genuine documentation change, which is part of the
+          #         release. A backend PR that merely edited documentation keeps its own
+          #         prefix — perf(gms), feat(assertions), feat(data products) — and is
+          #         correctly left out. The subject prefix is what separates the two; the path
+          #         alone cannot.
+          #
+          #    Requiring the parentheses matches the "(#NNNNN)" squash-merge suffix rather
+          #    than any PR mentioned mid-subject (e.g. "revert #18000 (#18955)").
           # shellcheck disable=SC2086
-          PR_NUMBERS=$(git log "$PREV_TAG".."$TAG" --format="%s" --no-merges -- $RELEASE_PATHSPECS \
-            | grep -oE '\(#[0-9]+\)' \
-            | tr -d '(#)' | sort -u)
+          CODE_PRS=$(git log "$PREV_TAG".."$TAG" --format="%s" --no-merges -- $RELEASE_PATHSPECS \
+            | grep -oE '\(#[0-9]+\)' | tr -d '(#)')
+          DOCS_PRS=$(git log "$PREV_TAG".."$TAG" --format="%s" --no-merges -- docs/ \
+            | grep -E '^docs[(:]' \
+            | grep -oE '\(#[0-9]+\)' | tr -d '(#)')
+          PR_NUMBERS=$(printf '%s\n%s\n' "$CODE_PRS" "$DOCS_PRS" | grep . | sort -u)
 
           if [ -z "$PR_NUMBERS" ]; then
             echo "No PRs found in range $PREV_TAG..$TAG"

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -85,12 +85,19 @@ on:
 env:
   CLI_NEXT_RELEASE_ID: "7de48387-0024-4156-9c60-33a237985f65"
   LINEAR_PIPELINE_ID: "1dded0ef-0a6a-421a-805b-2761579688b4"
-  # Repo-relative globs, matching this workflow's own push/PR path filters. Set explicitly
-  # because the pipeline-side default was owner/repo-qualified
-  # ("acryldata/datahub/metadata-ingestion/**"), which matches no commit path — every sync
-  # then logged "Found 0 matching commits" and skipped release creation, so the follow-up
-  # `complete` failed with "No release found with version <v>".
-  INCLUDE_PATHS: "metadata-ingestion/**,docs/**"
+  # Repo-relative globs. Set explicitly because the pipeline-side default was
+  # owner/repo-qualified ("acryldata/datahub/metadata-ingestion/**"), which matches no commit
+  # path — every sync then logged "Found 0 matching commits" and skipped release creation, so
+  # the follow-up `complete` failed with "No release found with version <v>".
+  #
+  # Scope matches the oss-release changelog filter, i.e. what the release actually ships to
+  # PyPI: the CLI plus the sibling plugin packages. metadata-ingestion-modules/ and
+  # datahub-actions/ are included for that reason — a `release: published` event publishes
+  # acryl-datahub-actions and the airflow/dagster/gx/prefect plugins too.
+  # Keep in sync with RELEASE_PATHSPECS below.
+  INCLUDE_PATHS: "metadata-ingestion/**,metadata-ingestion-modules/**,datahub-actions/**,docs/**"
+  # Same scope as INCLUDE_PATHS, in git pathspec form for `git log`.
+  RELEASE_PATHSPECS: "metadata-ingestion/ metadata-ingestion-modules/ datahub-actions/ docs/"
 
 jobs:
   # ── JOB 1: PR MERGED → add associated Linear issue to cli-next ──────────────
@@ -224,24 +231,39 @@ jobs:
           fi
           echo "Linear release ID for $TAG: $RELEASE_ID"
 
-          # 2. Find the previous tag via git ancestry, not chronological order.
-          #    git describe walks the commit graph backwards from TAG^ and finds the
-          #    nearest ancestor tag — correctly handles cherry-pick/backport releases
-          #    (e.g. v1.5.0.13.post3 → v1.5.0.13.post2, not v1.5.0.19 which was
-          #    published around the same time but is on a different branch).
-          PREV_TAG=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null)
+          # 2. Pick the comparison base the same way the oss-release skill does, so a
+          #    release's Linear issues match the PRs in its published release notes.
+          #
+          #    Stable: compare against the previous STABLE tag. A stable is promoted from the
+          #    final RC and therefore tags the same commit, so the nearest ancestor tag is
+          #    that RC — basing on it would capture only the last RC's delta and drop every
+          #    earlier RC's work. For v1.7.0.2 that was the difference between 14 PRs and 25.
+          #    Tags are matched on 3- and 4-segment forms, since major bumps (v1.7.0) are
+          #    3-segment by design.
+          #
+          #    RC: compare against the immediately preceding tag, giving the narrow RC-to-RC
+          #    delta that `oss-release rc` notes describe.
+          if echo "$TAG" | grep -q 'rc'; then
+            PREV_TAG=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null)
+          else
+            PREV_TAG=$(git tag --merged "${TAG}^" --sort=-v:refname \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$' | head -1)
+          fi
           if [ -z "$PREV_TAG" ]; then
             echo "No previous tag found — cannot determine commit range"
             exit 0
           fi
           echo "Commit range: $PREV_TAG..$TAG"
 
-          # 3. Extract PR numbers from commits actually in this release's range.
-          #    git log --cherry-pick --right-only handles cherry-picks correctly:
-          #    only commits unique to TAG (not already in PREV_TAG) are included.
-          PR_NUMBERS=$(git log "$PREV_TAG".."$TAG" --format="%s" --no-merges \
+          # 3. Extract PR numbers from commits in this release's range, scoped to the paths
+          #    that actually ship. Without the pathspec the range also yields GMS, GraphQL and
+          #    web-react PRs, which do not ship in these packages and do not belong in this
+          #    pipeline. Requiring the parentheses matches the "(#NNNNN)" squash-merge suffix
+          #    rather than any PR mentioned mid-subject (e.g. "revert #18000 (#18955)").
+          # shellcheck disable=SC2086
+          PR_NUMBERS=$(git log "$PREV_TAG".."$TAG" --format="%s" --no-merges -- $RELEASE_PATHSPECS \
             | grep -oE '\(#[0-9]+\)' \
-            | tr -d '(#)')
+            | tr -d '(#)' | sort -u)
 
           if [ -z "$PR_NUMBERS" ]; then
             echo "No PRs found in range $PREV_TAG..$TAG"


### PR DESCRIPTION
Linear release tracking has recorded nothing since **2026-05-22**. In that window **34 release-triggered runs failed**, each ending with:

```
Error: Not found - No release found with version "<v>" for the specified pipeline.
```

## Root cause

That error is a symptom. The preceding `sync` step **exits 0** while logging:

```
Found 0 matching commits between 181c304 and f579f9c
No matching commits found for include paths:
  acryldata/datahub/docs/**, acryldata/datahub/metadata-ingestion/**.
  Skipping release creation.
```

The path filters were **owner/repo-qualified**. Commit paths are repo-relative, so nothing could ever match — that range holds 984 commits, 441 of them touching the filtered directories. With no match, `sync` skips release creation and returns success; `complete` then fails one step later looking for a release that was never made.

It compounds: the scan base comes from the most recent release's `commitSha`, so with none created since May, every run re-scanned from the same stale commit (`181c304`, the commit that introduced this action).

## What this changes

**1. Commit scan matched nothing.** Repo-relative globs are now passed explicitly via the action's `include_paths` input, so the pipeline-side value cannot silently break the scan again.

**2. PR lookups queried the wrong repo.** The migration step extracts `(#NNNNN)` from commit subjects — those are **upstream** `datahub-project/datahub` numbers. This repo is a fork with unrelated, much lower PR numbering, so every lookup 404'd into the `// ""` fallback and the step silently reported "No Linear issues resolved". Now queries upstream.

The `add-to-cli-next` job still points at this repo, correctly — it uses `github.event.pull_request.number` from a fork PR event, which is a fork number.

**3. Attachment was gated on an empty staging area.** The step attached only issues present in **both** `cli-next` and the release's commit range. That intersection is empty whenever `cli-next` is — the steady state here, since `add-to-cli-next` fires on `pull_request_target` and this fork mostly receives upstream sync-merges rather than individual PRs. `cli-next` has held 0 issues since May, so the release got nothing attached even when the range resolved issues. Attachment now derives from the release's own commit range, with `cli-next` treated purely as a staging area to clean up afterwards.

**4. PR-to-ticket resolution was too narrow.** It read only the `Linear:` comment that `pr-to-linear.yml` posts on this fork; upstream PRs mostly lack it. Three directions are now unioned:

- (a) the `Linear:` comment, unchanged — still restricted to that exact prefix, since a bare identifier in a comment is usually a reviewer citing some other ticket
- (b) identifiers in the **branch name or title**, which Linear's copy-git-branch convention makes the largest single source
- (c) `attachmentsForURL`, the reverse lookup for tickets carrying the PR as an attachment — the only direction that finds a link made purely on the Linear side

Identifiers are uppercased (branch names are conventionally lowercase) and deduped, since several PRs commonly share one ticket.

The PR **body** is deliberately not searched: it routinely cites adjacent tickets (`part 1 of the X work (CAT-2789 / CAT-2783)`) that are not what the PR shipped, and it surfaced no identifier the branch name did not already give. Word boundaries matter for the same reason — without them `phase-1` matches the `SE` prefix and yields a bogus `SE-1`.

**5. Release scope was wrong in both directions.**

*Base tag* — the step used the nearest ancestor tag. A stable is promoted from its final RC and tags the same commit, so that ancestor is the last RC: for `v1.7.0.2` it resolved to `v1.7.0.2rc2`, capturing only that RC's delta and dropping every earlier RC's work. Stables now compare against the previous **stable** tag, matching how release notes are regenerated over `LAST_STABLE..RC_SHA`. RCs keep the narrow previous-tag delta. Stable matching accepts 3- and 4-segment forms, since major bumps (`v1.7.0`) are 3-segment by design.

*Paths* — the range was unfiltered, so it also yielded GMS, GraphQL and web-react PRs. It is now scoped to what the release publishes to PyPI: `metadata-ingestion/`, `metadata-ingestion-modules/` and `datahub-actions/`. A `release: published` event publishes `acryl-datahub-actions` and the airflow/dagster/gx/prefect plugins too, so those belong.

Top-level `docs/` is **excluded** — a change confined to it ships in none of these packages, and including it swept in backend and SaaS work that merely updated documentation (`perf(gms)` #18693, `feat(assertions)` #18771, `feat(data products)` #18890, the last of which pulled a Catalog ticket into an ingestion release). Connector documentation is unaffected: it lives under `metadata-ingestion/docs/sources/`, inside a code path.

**6. Backfill hygiene.** Two additions for manual backfills:

- a `base_ref` dispatch input, so a backfill can scope its scan instead of reaching back to a stale baseline
- the dispatch path now checks out the tag named by `version` first. The action derives a release's commit from `HEAD` and has no input for it — on a `release` event HEAD is already the tagged commit, but a dispatch checks out the ref it was launched from, so a backfill from a branch stamps the release with that branch's tip. That SHA becomes the scan baseline for later runs, so a wrong value silently mis-scopes every subsequent sync, and breaks range resolution outright if the branch is deleted.

## Result on v1.7.0.2

| | before | after |
|---|---|---|
| Base tag | `v1.7.0.2rc2` (last RC) | `v1.7.0` (last stable) |
| Path scope | unfiltered | shipping packages only |
| PRs in range | 24 | **18** |
| Tickets attached | 0 | **5** |

18 PRs is exactly the wheel-shipping set, so the Linear pipeline and the published release notes now derive from the same commits. Against the previous behaviour this adds the 11 shipped PRs that were being dropped and removes 17 that ship in none of these packages.

Resolved tickets: `ING-2778`, `ING-2812`, `ING-3014`, `OBS-2056`, `OSS-1075`.

Worth a reviewer's eye: **`OBS-2056` is an umbrella ticket spanning backend and ingestion.** It attaches on the strength of PRs with 17 and 7 files under `metadata-ingestion/`, while its backend-only PR is excluded by the path scope. That is the intended behaviour under this rule, but it is the case most likely to prompt a question.

## Verification

Dispatched against this branch ([run 31386538844](https://github.com/acryldata/datahub/actions/runs/31386538844)) — the first successful sync since May:

```
INPUT_INCLUDE_PATHS: metadata-ingestion/**,docs/**
INPUT_BASE_REF: v1.7.0
Using --base-ref v1.7.0 (81aeed6); skipping automatic baseline selection
Found 28 matching commits in requested range          ← was 0
Synced to release (version: v1.7.0.2): pull requests [...]
Stored release baseline: <head>
```

That run used the then-current two-path scope; the final scope in this PR narrows the set to 18 PRs. It confirmed items 1 and 6, created the `v1.7.0.2` release object, and surfaced the HEAD-stamping problem — it recorded the branch tip as the release commit, which has since been corrected on the release object and fixed here so it cannot recur.

A second dispatch, from `master` rather than this branch ([run 31390408774](https://github.com/acryldata/datahub/actions/runs/31390408774)), independently confirms the diagnosis in item 1. `master` passes no `include_paths`, so the action fell back to the pipeline-side value:

```
INPUT_INCLUDE_PATHS: 
Found 12 matching commits between f579f9c and 4f91ab2
```

12 of the 35 commits in that range matched — via the same code path that returned 0 for three months, and at the code-path figure rather than the 17 that including `docs/` would give.

That run also re-demonstrated item 6. Launched from `master`, which lacks the tag-pinning fix, it stamped the release with the branch `HEAD` instead of the release commit. That was corrected on the release object; with this PR merged, a dispatch pins `HEAD` to the tag first and cannot do it again.

Items 3, 4 and 5 are verified by local reproduction against this release's real data — resolution and scoping were run over all 25 candidate PRs and the outputs checked by hand — but have not yet executed inside CI. They need a merged workflow or a live release event.

## Notes for reviewers

Path filters are **also** configured pipeline-side in Linear (Settings → Releases). That value was owner/repo-qualified and has since been corrected there. `include_paths` is set in this workflow as well so the scope is explicit and reviewable in CI — whether the input overrides or composes with the pipeline setting is undocumented, so setting both removes the ambiguity.

The pipeline-side value has since been aligned with the scope in this PR, so the two agree whichever way the action resolves them.

Issue attachment will remain partial, largely for a legitimate reason: only a minority of PRs in a release have any Linear ticket. Community contributions, routine fixes and docs updates often have none. This PR takes the attached count from a structural zero to the tickets that genuinely exist.

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] `actionlint` passes (pre-commit)
- [x] Shell logic reproduced locally against real release data
- [ ] Tests added/updated — n/a, CI workflow change
- [ ] Breaking changes documented — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


