### PR TITLE
fix(ci): add least-privilege permissions and stop the push sync clobbering releases

### DIFF
--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -281,11 +281,22 @@ jobs:
           TAG: ${{ env.RELEASE_VERSION }}
         run: |
           # 1. Find the Linear release we just created/synced (match by version + pipeline)
-          RELEASE_ID=$(curl -s -X POST https://api.linear.app/graphql \
+          RESP=$(curl -s -X POST https://api.linear.app/graphql \
             -H "Authorization: $LINEAR_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{\"query\": \"{ releasePipeline(id: \\\"$LINEAR_PIPELINE_ID\\\") { releases(filter: { version: { eq: \\\"$TAG\\\" } }) { nodes { id } } } }\"}" \
-            | jq -r '.data.releasePipeline.releases.nodes[0].id // empty')
+            -d "{\"query\": \"{ releasePipeline(id: \\\"$LINEAR_PIPELINE_ID\\\") { releases(filter: { version: { eq: \\\"$TAG\\\" } }) { nodes { id } } } }\"}")
+
+          # Surface API errors instead of coercing them to "not found". An auth or scope
+          # failure returns errors[] with data:null, which the old `// empty` fallback
+          # rendered identically to a genuinely absent release — so a broken credential and
+          # a missing release were indistinguishable in the log.
+          if [ "$(printf '%s' "$RESP" | jq -r 'has("errors")')" = "true" ]; then
+            echo "::error::Linear API error querying release $TAG:"
+            printf '%s' "$RESP" | jq -c '.errors[]' | sed 's/^/  /'
+            exit 1
+          fi
+
+          RELEASE_ID=$(printf '%s' "$RESP" | jq -r '.data.releasePipeline.releases.nodes[0].id // empty')
 
           if [ -z "$RELEASE_ID" ]; then
             echo "Could not find Linear release for $TAG — skipping migration"

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -14,10 +14,16 @@ name: Linear — Ingestion CLI/PyPI Release Tracking
 # Required secrets:
 #   LINEAR_ACCESS_KEY     — pipeline access key (Linear Settings → Releases → CI setup).
 #                           Used by linear-release-action. Scoped to release-pipeline ops only.
-#   INGESTION_LINEAR_KEY  — personal API key (already used by pr-to-linear.yml).
+#   INGESTION_LINEAR_KEY  — personal API key (also used by pr-to-linear.yml).
 #                           Used for direct GraphQL calls (issueToReleaseCreate,
 #                           issueToReleaseDeleteByIssueAndRelease, releaseDelete, issue lookups)
 #                           — the pipeline access key cannot authorize these.
+#                           NOTE: pr-to-linear.yml and linear-assignment-notify.yml also live
+#                           upstream in datahub-project/datahub, which is where that secret is
+#                           configured. Secrets do not cross the fork boundary, so this key must
+#                           be added to THIS repo as well; when it is missing, GitHub substitutes
+#                           an empty string and every Linear call silently 401s (releases get
+#                           created but end up with zero issues attached).
 
 on:
   pull_request_target:
@@ -114,6 +120,12 @@ jobs:
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    # This repo's default workflow permission is "read", which grants only
+    # contents/metadata/packages — `gh pr view --json comments` needs pull-requests.
+    # Nothing here writes to GitHub; all writes go to Linear over its own API.
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Find Linear issue from PR comment
         id: find-issue
@@ -164,6 +176,12 @@ jobs:
       (github.event_name == 'release' && github.event.action == 'published') ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    # contents: read      → actions/checkout, and linear-release-action's github_token
+    #                       (it uses it only to download the Linear release CLI)
+    # pull-requests: read → the `gh pr view` lookups in the attach step
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -435,6 +453,8 @@ jobs:
   delete-linear-release:
     if: github.event_name == 'release' && github.event.action == 'deleted'
     runs-on: ubuntu-latest
+    # Talks only to the Linear API — no GitHub token needed at all.
+    permissions: {}
     steps:
       - name: Delete Linear release for ${{ github.event.release.tag_name }}
         env:

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -11,6 +11,12 @@ name: Linear — Ingestion CLI/PyPI Release Tracking
 #
 # Manual dispatch supports backfilling past releases and one-off stage overrides.
 #
+# There is deliberately no `push` trigger. linear-release-action's push sync is the pattern for
+# CONTINUOUS pipelines, where each push becomes its own release. This pipeline is `scheduled`, so
+# a versionless sync does not create anything — it targets the most recent release, rewrites its
+# commitSha to master HEAD and attaches commits published after it. Staging work on merge is the
+# add-to-cli-next job's responsibility, via pull_request_target.
+#
 # Required secrets:
 #   LINEAR_ACCESS_KEY     — pipeline access key (Linear Settings → Releases → CI setup).
 #                           Used by linear-release-action. Scoped to release-pipeline ops only.
@@ -29,13 +35,6 @@ on:
   pull_request_target:
     types: [closed]
     branches: [master]
-    paths:
-      - "metadata-ingestion/**"
-      - "docs/**"
-
-  push:
-    branches:
-      - master
     paths:
       - "metadata-ingestion/**"
       - "docs/**"
@@ -172,7 +171,6 @@ jobs:
   # ── JOB 2: RELEASE PUBLISHED or MANUAL DISPATCH ─────────────────────────────
   linear-release:
     if: >
-      github.event_name == 'push' ||
       (github.event_name == 'release' && github.event.action == 'published') ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -187,14 +185,6 @@ jobs:
         with:
           fetch-depth: 0 # required — action scans full commit history
 
-      # ── 1. MERGE TO MASTER ────────────────────────────────────────────────
-      - name: Sync issues on merge to master
-        if: github.event_name == 'push'
-        uses: linear/linear-release-action@v0
-        with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
-          include_paths: ${{ env.INCLUDE_PATHS }}
-
       # ── 2. ANY RELEASE PUBLISHED, OR A MANUAL BACKFILL ───────────────────
 
       # Single source of truth for the version every step below operates on: the published
@@ -205,7 +195,6 @@ jobs:
       # The value goes through env rather than being interpolated into the run block — a tag
       # name is attacker-influenceable text and must not reach the shell as source.
       - name: Resolve release version
-        if: github.event_name != 'push'
         env:
           VERSION: ${{ github.event.release.tag_name || inputs.version }}
         run: echo "RELEASE_VERSION=${VERSION}" >> "$GITHUB_ENV"

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -185,7 +185,7 @@ jobs:
         with:
           fetch-depth: 0 # required — action scans full commit history
 
-      # ── 2. ANY RELEASE PUBLISHED, OR A MANUAL BACKFILL ───────────────────
+      # ── 1. RELEASE PUBLISHED (RC or stable) ──────────────────────────────
 
       # Single source of truth for the version every step below operates on: the published
       # tag on a release event, the operator-supplied version on a manual dispatch. Steps
@@ -234,7 +234,7 @@ jobs:
           command: complete
           version: ${{ env.RELEASE_VERSION }}
 
-      # ── 3. MANUAL DISPATCH ────────────────────────────────────────────────
+      # ── 2. MANUAL DISPATCH (backfill) ─────────────────────────────────────
 
       # The action takes the release's commit from HEAD — it has no input for it. On a
       # `release` event HEAD is already the tagged commit, but a dispatch checks out the ref
@@ -266,8 +266,13 @@ jobs:
           include_paths: ${{ env.INCLUDE_PATHS }}
           base_ref: ${{ inputs.base_ref }}
 
-      # Both RC and stable: attach the issues whose PRs are in this release's commit range,
-      # and de-stage any of them that were sitting in cli-next
+      # ── 3. EITHER PATH ────────────────────────────────────────────────────
+
+      # Attach the issues whose PRs are in this release's commit range, and de-stage any of
+      # them that were sitting in cli-next. Runs for a published release and for a backfill
+      # alike — it keys off RELEASE_VERSION, not the event. It must come last: on a release
+      # event the object already exists from the sync above, but on a dispatch it is created
+      # by the manual command, so attaching earlier would find no release and skip.
       - name: Attach release issues and clear them from cli-next
         if: env.RELEASE_VERSION != ''
         env:

--- a/.github/workflows/linear-release-tracking.yml
+++ b/.github/workflows/linear-release-tracking.yml
@@ -284,7 +284,7 @@ jobs:
           RESP=$(curl -s -X POST https://api.linear.app/graphql \
             -H "Authorization: $LINEAR_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{\"query\": \"{ releasePipeline(id: \\\"$LINEAR_PIPELINE_ID\\\") { releases(filter: { version: { eq: \\\"$TAG\\\" } }) { nodes { id } } } }\"}")
+            -d "{\"query\": \"{ releasePipeline(id: \\\"$LINEAR_PIPELINE_ID\\\") { releases(first: 250) { nodes { id version } } } }\"}")
 
           # Surface API errors instead of coercing them to "not found". An auth or scope
           # failure returns errors[] with data:null, which the old `// empty` fallback
@@ -296,7 +296,9 @@ jobs:
             exit 1
           fi
 
-          RELEASE_ID=$(printf '%s' "$RESP" | jq -r '.data.releasePipeline.releases.nodes[0].id // empty')
+          RELEASE_ID=$(printf '%s' "$RESP" \
+            | jq -r --arg v "$TAG" '.data.releasePipeline.releases.nodes[]
+                                    | select(.version == $v) | .id' | head -1)
 
           if [ -z "$RELEASE_ID" ]; then
             echo "Could not find Linear release for $TAG — skipping migration"
@@ -470,8 +472,9 @@ jobs:
           RELEASE_ID=$(curl -s -X POST https://api.linear.app/graphql \
             -H "Authorization: $LINEAR_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{\"query\": \"{ releasePipeline(id: \\\"$LINEAR_PIPELINE_ID\\\") { releases(filter: { version: { eq: \\\"$TAG\\\" } }) { nodes { id } } } }\"}" \
-            | jq -r '.data.releasePipeline.releases.nodes[0].id // empty')
+            -d "{\"query\": \"{ releasePipeline(id: \\\"$LINEAR_PIPELINE_ID\\\") { releases(first: 250) { nodes { id version } } } }\"}" \
+            | jq -r --arg v "$TAG" '.data.releasePipeline.releases.nodes[]
+                                    | select(.version == $v) | .id' | head -1)
 
           if [ -z "$RELEASE_ID" ]; then
             echo "No Linear release found for $TAG — nothing to delete"


### PR DESCRIPTION
Two independent bugs in the Linear release workflow, both of which fail silently.

## 1. The jobs had no GitHub permissions they needed

This repo's `default_workflow_permissions` is `read`, which grants only contents / metadata / packages. `pull-requests` is `none`, so every `gh pr view --json comments` lookup — the PR-to-ticket resolution in the attach step, and the issue lookup in `add-to-cli-next` — was failing.

Per-job scopes are now declared explicitly, least privilege:

| Job | Permissions | Why |
| --- | --- | --- |
| `add-to-cli-next` | `contents: read`, `pull-requests: read` | `gh pr view --json comments` |
| `linear-release` | `contents: read`, `pull-requests: read` | `actions/checkout`, the action's CLI download, and the attach step's PR lookups |
| `delete-linear-release` | `{}` | talks only to `api.linear.app` |

Note an explicit `permissions:` block is **subtractive** — anything not listed becomes `none` — so `contents: read` has to be re-declared or `actions/checkout` breaks. No job needs any write scope on GitHub: the workflow reads GitHub and writes only to Linear.

## 2. The push sync dumps post-release commits into a versioned release

`linear-release-action`'s push sync is the pattern for **continuous** pipelines, where each push becomes its own release. This pipeline is `scheduled`, so a versionless sync creates nothing — it targets the **most recent release**, rewrites its `commitSha` to master HEAD, and attaches commits published after it.

Not hypothetical. On 2026-08-11 a push run did this:

```
Found 19 matching commits between f579f9c and 5f70929
Synced to release v1.7.0.2 (version: v1.7.0.2): pull requests [17 PRs]
```

The target is not "the newest release" — it is whichever release sits in the pipeline's initial `In Progress` stage, the accumulator slot. `v1.7.0.2` has occupied that slot since it was created and never completed, so it has absorbed **every** ingestion push since 2026-08-11. Its `commitSha` has been walked forward from `f579f9c4` (its tag) to master HEAD, currently `7461cd25`, and it now carries a long tail of PRs that shipped in later releases.

Properly published releases are unaffected — `v1.7.0.5` through `v1.7.0.8rc1` all still carry their own tag's commit — so the damage is confined to one release acting as a junk drawer. But the accumulator for this pipeline is meant to be the `cli-next` placeholder, which `add-to-cli-next` writes to; the action has no knowledge of it and picks a versioned release instead.

The behaviour was dormant for three months only because the owner/repo-qualified path filters made every push match zero commits and skip. Fixing those filters in #403 reactivated it — so this is a regression introduced by that fix.

The `push` trigger and its step are removed. Staging on merge is already `add-to-cli-next`'s job, via `pull_request_target`, writing to the `cli-next` release rather than to a versioned one.

## Not fixed here

`INGESTION_LINEAR_KEY` does not exist as a secret in this repo. The workflows that share it (`pr-to-linear.yml`, `linear-assignment-notify.yml`) live upstream in `datahub-project/datahub`, where it is configured, and secrets do not cross the fork boundary. When it is missing GitHub substitutes an empty string, so every direct Linear GraphQL call 401s and the step exits 0 — releases get created with zero issues attached.

That needs a repo (or scoped org) secret containing a Linear personal API key with **Read + Write**, and access to **all** teams whose issues can appear in a release — the five tickets resolved for `v1.7.0.2` span four (Ingestion Pod, Observability Squad, Open Source, Catalog). A key limited to one team would return null for the rest and skip them silently.

`LINEAR_ACCESS_KEY` is already present but is not a substitute: it is a release-pipeline access key for the `linear-release` CLI and cannot authorize `issueToReleaseCreate`, `issueToReleaseDeleteByIssueAndRelease`, `releaseDelete`, or issue lookups.

Once the secret exists, `v1.7.0.2` needs its `commitSha` reset to `f579f9c4` and a re-run of `sync` to attach its issues. Doing that before this PR merges would simply be overwritten by the next push.

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] `actionlint` and `githubActionsPrettierCheck` pass
- [ ] Tests added/updated — n/a, CI workflow change
- [ ] Breaking changes documented — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

