### PR TITLE
feat(cli): load cloud evals command

### DIFF
--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -601,6 +601,8 @@ try:
 
     datahub.add_command(evals)
 except ImportError as e:
+    if "acryl_datahub_cloud" not in str(e):
+        raise
     logger.debug(f"Failed to load datahub evals command: {e}")
     datahub.add_command(
         make_shim_command("evals", "run `pip install acryl-datahub-cloud`")

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -57,6 +57,14 @@ _logging_configured: Optional[ContextManager] = None
 
 MAX_CONTENT_WIDTH = 120
 
+
+def _evals_import_suggestion(error: ImportError) -> str:
+    if "acryl_datahub_cloud" in str(error):
+        return "run `pip install acryl-datahub-cloud`"
+    logger.warning(f"acryl-datahub-cloud is installed but failed to load: {error}")
+    return f"fix the acryl-datahub-cloud installation ({error})"
+
+
 if sys.version_info >= (3, 12):
     click.secho(
         "Python versions above 3.11 are not actively tested with yet. Please use Python 3.11 for now.",
@@ -601,12 +609,7 @@ try:
 
     datahub.add_command(evals)
 except ImportError as e:
-    if "acryl_datahub_cloud" in str(e):
-        suggestion = "run `pip install acryl-datahub-cloud`"
-    else:
-        logger.warning(f"acryl-datahub-cloud is installed but failed to load: {e}")
-        suggestion = f"fix the acryl-datahub-cloud installation ({e})"
-    datahub.add_command(make_shim_command("evals", suggestion))
+    datahub.add_command(make_shim_command("evals", _evals_import_suggestion(e)))
 
 try:
     from datahub.cli.iceberg_cli import iceberg

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -601,12 +601,12 @@ try:
 
     datahub.add_command(evals)
 except ImportError as e:
-    if "acryl_datahub_cloud" not in str(e):
-        raise
-    logger.debug(f"Failed to load datahub evals command: {e}")
-    datahub.add_command(
-        make_shim_command("evals", "run `pip install acryl-datahub-cloud`")
-    )
+    if "acryl_datahub_cloud" in str(e):
+        suggestion = "run `pip install acryl-datahub-cloud`"
+    else:
+        logger.warning(f"acryl-datahub-cloud is installed but failed to load: {e}")
+        suggestion = f"fix the acryl-datahub-cloud installation ({e})"
+    datahub.add_command(make_shim_command("evals", suggestion))
 
 try:
     from datahub.cli.iceberg_cli import iceberg

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -597,6 +597,16 @@ datahub.add_command(api)
 datahub.add_command(agent_skill)
 
 try:
+    from acryl_datahub_cloud.cli.evals import evals
+
+    datahub.add_command(evals)
+except ImportError as e:
+    logger.debug(f"Failed to load datahub evals command: {e}")
+    datahub.add_command(
+        make_shim_command("evals", "run `pip install acryl-datahub-cloud`")
+    )
+
+try:
     from datahub.cli.iceberg_cli import iceberg
 
     datahub.add_command(iceberg)

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -16,6 +16,25 @@ def test_agent_shim_command_behavior():
     assert "run `pip install datahub-agent-context`" in result.output
 
 
+@pytest.mark.parametrize(
+    "error,expected",
+    [
+        (
+            ImportError("No module named acryl_datahub_cloud"),
+            "pip install acryl-datahub-cloud",
+        ),
+        (
+            ImportError("No module named graphql"),
+            "fix the acryl-datahub-cloud installation",
+        ),
+    ],
+)
+def test_evals_import_suggestion(error, expected):
+    from datahub.entrypoints import _evals_import_suggestion
+
+    assert expected in _evals_import_suggestion(error)
+
+
 def test_agent_command_exists():
     """Test that agent command is registered in the CLI."""
     import datahub.entrypoints

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -42,7 +42,7 @@ def test_agent_command_shows_error_or_help():
 
 @pytest.mark.parametrize(
     "command_name",
-    ["agent", "actions", "lite"],
+    ["agent", "actions", "evals", "lite"],
 )
 def test_optional_commands_exist(command_name):
     """Test that optional commands (agent, actions, lite) are always registered."""
@@ -57,6 +57,7 @@ def test_optional_commands_exist(command_name):
     [
         ("agent", "pip install datahub-agent-context"),
         ("actions", "pip install acryl-datahub-actions"),
+        ("evals", "pip install acryl-datahub-cloud"),
         ("lite", "pip install 'acryl-datahub[datahub-lite]'"),
     ],
 )

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -45,7 +45,7 @@ def test_agent_command_shows_error_or_help():
     ["agent", "actions", "evals", "lite"],
 )
 def test_optional_commands_exist(command_name):
-    """Test that optional commands (agent, actions, lite) are always registered."""
+    """Test that optional commands are always registered."""
     import datahub.entrypoints
 
     # Verify the command exists in the CLI


### PR DESCRIPTION
## Summary

- Load the optional cloud evals command into the OSS `datahub` CLI.
- Keep the evals command available as a shim when the cloud package or one of its dependencies cannot load, with an install or repair message appropriate to the failure.
- Add coverage for both import-fallback messages and update the optional-command test documentation.

## Testing

- `./gradlew :metadata-ingestion:lintFix`
- Focused entrypoint tests: 13 passed.
- Full ingestion build: 16,404 passed, 27 skipped, 21 unrelated environment or dependency failures, and 1 unrelated collection error.
- Verified `datahub evals --help` with local OSS and cloud source paths and verified the missing-package shim.