### PR TITLE
test(smoke): fix flaky test_list_groups and container smoke tests

### DIFF
--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -752,6 +752,11 @@ def test_list_users(auth_session):
 
 
 @pytest.mark.dependency()
+# The bootstrapped groups come from bootstrap_mce.json and are only visible here
+# once Elasticsearch has indexed them. wait_for_writes_to_sync() inside
+# execute_graphql() only covers the write pipeline, not the search refresh, so
+# an unretried run can legitimately see fewer than the 2 expected groups.
+@with_test_retry()
 def test_list_groups(auth_session):
     query = """query listGroups($input: ListGroupsInput!) {
         listGroups(input: $input) {

--- a/smoke-test/tests/containers/containers_test.py
+++ b/smoke-test/tests/containers/containers_test.py
@@ -1,22 +1,75 @@
+import logging
+from dataclasses import dataclass
 from typing import Any, Dict
 
 import pytest
 
-from conftest import _ingest_cleanup_data_impl
 from tests.utilities.metadata_operations import add_tag, add_term, update_description
-from tests.utils import execute_graphql
+from tests.utils import (
+    delete_urns_from_file,
+    execute_graphql,
+    ingest_file_via_rest,
+    materialize_with_unique_name,
+    with_test_retry,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ContainerUrns:
+    """Run-unique URNs of the containers ingested by :func:`ingest_cleanup_data`."""
+
+    schema_urn: str
+    database_urn: str
 
 
 @pytest.fixture(scope="module", autouse=False)
-def ingest_cleanup_data(auth_session, graph_client):
-    yield from _ingest_cleanup_data_impl(
-        auth_session, graph_client, "tests/containers/data.json", "containers"
+def ingest_cleanup_data(auth_session, graph_client, tmp_path_factory):
+    """Ingest the container fixtures under run-unique container URNs.
+
+    data.json used to hardcode ``urn:li:container:SCHEMA`` and
+    ``urn:li:container:DATABASE``. Under pytest-xdist ``--dist=loadscope`` (see
+    smoke-test/smoke.sh) test modules run concurrently against the same GMS, so
+    another module's teardown could delete those containers while this module
+    was mid-query. Rewriting both keys to a run-unique value gives this module
+    sole ownership of the entities it asserts on.
+
+    ``SCHEMA`` and ``DATABASE`` are uppercase and occur in data.json only inside
+    the container URNs, which is what ``materialize_with_unique_name`` requires
+    (its substitution is a plain, case-sensitive replace over the whole file).
+    The human-readable ``datahub_schema``/``datahub_db`` names are lowercase and
+    so are deliberately left untouched.
+    """
+    tmp_dir = tmp_path_factory.mktemp("containers")
+    data_file, schema_key = materialize_with_unique_name(
+        "tests/containers/data.json", "SCHEMA", tmp_dir
     )
+    data_file, database_key = materialize_with_unique_name(
+        data_file, "DATABASE", tmp_dir
+    )
+    urns = ContainerUrns(
+        schema_urn=f"urn:li:container:{schema_key}",
+        database_urn=f"urn:li:container:{database_key}",
+    )
+
+    # No pre-ingest idempotency delete: the URNs are freshly unique per run, so
+    # nothing pre-exists to clean up.
+    logger.info(f"ingesting containers test data (schema={urns.schema_urn})")
+    ingest_file_via_rest(auth_session, data_file)
+    yield urns
+    logger.info("removing containers test data")
+    delete_urns_from_file(graph_client, data_file)
 
 
 @pytest.mark.dependency()
+# The query below reads platform, subTypes, editableProperties and related
+# entities in one shot, and each aspect is indexed independently -- a single
+# lagging aspect fails an otherwise correct run. The test is a pure read, so
+# retrying it is safe.
+@with_test_retry()
 def test_get_full_container(auth_session, ingest_cleanup_data):
-    container_urn = "urn:li:container:SCHEMA"
+    container_urn = ingest_cleanup_data.schema_urn
     container_name = "datahub_schema"
     container_description = "The DataHub schema"
     editable_container_description = "custom description"
@@ -103,6 +156,7 @@ def test_get_full_container(auth_session, ingest_cleanup_data):
     assert container["platform"]["urn"] == "urn:li:dataPlatform:mysql"
     assert container["properties"]["name"] == container_name
     assert container["properties"]["description"] == container_description
+    assert container["container"]["urn"] == ingest_cleanup_data.database_urn
     assert container["subTypes"]["typeNames"][0] == "Schema"
     assert (
         container["editableProperties"]["description"] == editable_container_description
@@ -114,7 +168,7 @@ def test_get_full_container(auth_session, ingest_cleanup_data):
 
 
 @pytest.mark.dependency(depends=["test_get_full_container"])
-def test_get_parent_container(auth_session):
+def test_get_parent_container(auth_session, ingest_cleanup_data):
     dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"
 
     # Get count of existing secrets
@@ -140,8 +194,8 @@ def test_get_parent_container(auth_session):
 
 
 @pytest.mark.dependency(depends=["test_get_full_container"])
-def test_update_container(auth_session):
-    container_urn = "urn:li:container:SCHEMA"
+def test_update_container(auth_session, ingest_cleanup_data):
+    container_urn = ingest_cleanup_data.schema_urn
 
     # add_tag/add_term/addOwner/addLink below are back-to-back writes to the same
     # container with no intermediate read -- only the combined state after the


### PR DESCRIPTION
`Pytest Smoke Tests (Batch 3/7)` failed on `master` for `b0e664f` in `test_list_groups` and `test_get_full_container`. Both are flakes — neither has ever failed on a retry attempt — but neither had any test-level retry coverage, so a single lagging index read fails the whole batch.

## `test_e2e.py::test_list_groups`

The test asserts `len(groups) >= 2` against the groups bootstrapped from `bootstrap_mce.json`. `execute_graphql()` calls `wait_for_writes_to_sync()`, but that only covers the write pipeline — it does not guarantee the Elasticsearch search index has been refreshed. If it hasn't, the assertion fails with no second chance.

Added `@with_test_retry()`. The test is a pure read, so retrying is safe.

## `tests/containers/containers_test.py`

Two interacting problems:

1. **Shared hard-coded URNs.** `data.json` hardcoded `urn:li:container:SCHEMA` and `urn:li:container:DATABASE`. Phase 1 of `smoke.sh` runs under `pytest-xdist --dist=loadscope`, so modules execute concurrently against the same GMS and another module's teardown can delete a container while this module is mid-query.
2. **Non-atomic aspect reads.** The query pulls `platform`, `subTypes`, `editableProperties`, `container` and related entities in one shot; each is indexed independently, so one lagging aspect fails an otherwise correct run.

Changes:

- The module fixture now rewrites both container keys to run-unique values via the existing `materialize_with_unique_name()` helper before ingesting, and yields them as a frozen `ContainerUrns` dataclass. This follows the same pattern already used by `tests/delete/delete_test.py` and `_ingest_cleanup_unique_dataset_impl`. Both keys are uppercase and appear in `data.json` only inside container URNs, which is the substitution contract that helper requires — the human-readable `datahub_schema` / `datahub_db` names are lowercase and are deliberately left untouched.
- Added `@with_test_retry()` to `test_get_full_container`.
- `test_get_parent_container` and `test_update_container` now request the fixture explicitly instead of relying on `test_get_full_container` having instantiated it first — per `smoke-test/CLAUDE.MD`, tests should not depend on run order.
- `test_get_full_container` now also asserts the parent container URN. The query already fetched `container { urn }` but asserted nothing about it; this makes the parent link an actual check rather than dead query surface.

There is no pre-ingest idempotency delete anymore, matching `_ingest_cleanup_unique_dataset_impl`: the URNs are freshly unique per run, so nothing pre-exists to clean up.

## Testing

- `./gradlew :smoke-test:lintFix` — ruff check passed, `ruff format` left both files unchanged, mypy clean across 309 files.
- Verified the URN substitution offline against the real `data.json`: both container URNs are rewritten, the parent↔child container link stays internally consistent, and `datahub_schema` / `datahub_db` are preserved.
- Verified the new decorator/fixture shape in isolation (`@pytest.mark.dependency()` + `@with_test_retry()` over a module-scoped fixture): tenacity's wrapper does not hide fixture params from pytest's fixture resolution, the retry genuinely re-runs the test body, and `depends=[...]` chaining still resolves.
- End-to-end validation needs a live GMS/OpenSearch/Kafka stack, so the real signal is the smoke job on this PR.

## Notes / out of scope

- `test_list_users`, immediately above `test_list_groups`, has the same eventual-consistency shape and also lacks retry coverage. Left alone to keep this change scoped to the reported failures.
- The module still shares `SampleHiveDataset`, `urn:li:tag:Test` and `urn:li:glossaryTerm:Term` with other modules, and its cleanup still deletes them — pre-existing behaviour, unchanged here.
- Batch 3/7 has 8 confirmed *persistent* failure episodes over the last 14 days; this PR addresses the flake profile only, not that underlying reliability problem.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests updated
- [ ] Docs — n/a
- [ ] Breaking changes — none
